### PR TITLE
uci.c: Change to 1/20 of time as default

### DIFF
--- a/Source/uci.c
+++ b/Source/uci.c
@@ -401,8 +401,8 @@ static inline void time_control(position_t *pos, thread_t *threads,
   threads->timeset = 0;
   memset(&limits, 0, sizeof(limits_t));
 
-  // Default to 1/30 of the time to spend
-  limits.movestogo = 30;
+  // Default to 1/20 of the time to spend
+  limits.movestogo = 20;
 
   threads[0].starttime = get_time_ms();
 


### PR DESCRIPTION
LTC
Elo   | 16.85 +- 5.87 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 4148 W: 1204 L: 1003 D: 1941
Penta | [34, 392, 1037, 561, 50]

STC
Elo   | 25.63 +- 7.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 3.00]
Games | N: 3218 W: 1094 L: 857 D: 1267
Penta | [52, 303, 713, 438, 103]