### PR TITLE
search.c: store best_score instead of alpha on fail low

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -319,7 +319,7 @@ static inline int quiescence(position_t *pos, thread_t *thread, int alpha,
       alpha = score;
     }
   }
-  write_hash_entry(pos, alpha, 0, best_move, hash_flag);
+  write_hash_entry(pos, best_score, 0, best_move, hash_flag);
   // node (position) fails low
   return best_score;
 }


### PR DESCRIPTION
bench: 4048485

Elo   | 0.42 +- 2.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 22246 W: 5771 L: 5744 D: 10731
Penta | [322, 2651, 5159, 2660, 331]
