### PR TITLE
Late Move Pruning

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -568,8 +568,21 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
   // number of moves searched in a move list
   int moves_searched = 0;
 
+  int quiet_count = 0;
+
   // loop over moves within a movelist
   for (uint32_t count = 0; count < move_list->count; count++) {
+    int list_move = move_list->entry[count].move;
+    uint8_t quiet = (get_move_capture(list_move) == 0);
+
+    if (quiet) {
+      quiet_count++;
+    }
+
+    if (!pv_node && !in_check && quiet && depth <= 3 &&
+        quiet_count > 6 + (depth * depth * 2)) {
+      break;
+    }
 
     int move = move_list->entry[count].move;
     uint8_t is_quiet = get_move_capture(move) == 0;

--- a/Source/search.c
+++ b/Source/search.c
@@ -579,7 +579,7 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
       quiet_count++;
     }
 
-    if (!pv_node && !in_check && quiet && depth <= 3 &&
+    if (!pv_node && !in_check && quiet &&
         quiet_count > 6 + (depth * depth * 2)) {
       break;
     }


### PR DESCRIPTION
Elo   | 12.72 +- 6.32 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3442 W: 853 L: 727 D: 1862
Penta | [20, 365, 830, 481, 25]

Elo   | 11.72 +- 6.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4388 W: 1208 L: 1060 D: 2120
Penta | [65, 463, 1010, 571, 85]

Gains aprox 12 elo on STC and LTC.

The formula is VERY much not final.