### PR TITLE
search.c: NMP to higher depth

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -448,7 +448,7 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
     }
 
     // null move pruning
-    if (do_null_pruning && depth >= 3 && pos->ply) {
+    if (do_null_pruning && depth >= 4 && pos->ply) {
       // preserve board state
       copy_board(pos->bitboards, pos->occupancies, pos->side, pos->enpassant,
                  pos->castle, pos->fifty, pos->hash_key, pos->mailbox,
@@ -476,7 +476,7 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
 
       /* search moves with reduced depth to find beta cutoffs
          depth - 1 - R where R is a reduction limit */
-      score = -negamax(pos, thread, -beta, -beta + 1, depth - 1 - 2, 0);
+      score = -negamax(pos, thread, -beta, -beta + 1, depth - 1 - 3, 0);
 
       // decrement ply
       pos->ply--;


### PR DESCRIPTION
Elo   | 37.06 +- 11.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1214 W: 386 L: 257 D: 571
Penta | [8, 101, 284, 182, 32]

bench: 3281216