### PR TITLE
search.c: NMP only if eval beats beta

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -448,7 +448,7 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
     }
 
     // null move pruning
-    if (do_null_pruning && depth >= 4 && pos->ply) {
+    if (do_null_pruning && depth >= 4 && pos->ply && static_eval >= beta) {
       // preserve board state
       copy_board(pos->bitboards, pos->occupancies, pos->side, pos->enpassant,
                  pos->castle, pos->fifty, pos->hash_key, pos->mailbox,


### PR DESCRIPTION
Elo   | 13.56 +- 6.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3590 W: 1009 L: 869 D: 1712
Penta | [39, 390, 825, 474, 67]

bench: 3158128