### PR TITLE
search.c: RFP to higher depths

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -434,8 +434,8 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
 
   int static_eval = evaluate(pos);
   if (!in_check) {
-    // evaluation pruning / static null move pruning
-    if (depth < 3 && !pv_node && abs(beta - 1) > -infinity + 100) {
+    // Reverse Futility Pruning
+    if (depth <= 6 && !pv_node && abs(beta - 1) > -infinity + 100) {
       // get static evaluation score
 
       // define evaluation margin


### PR DESCRIPTION
Elo   | 12.80 +- 6.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3666 W: 1006 L: 871 D: 1789
Penta | [34, 397, 860, 484, 58]

Elo   | 5.03 +- 3.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 5.00]
Games | N: 12652 W: 3399 L: 3216 D: 6037
Penta | [201, 1510, 2799, 1537, 279]

bench: 2659605