### PR TITLE
pvtable.c: Fix replacment condition in TT

### DIFF
--- a/Source/pvtable.c
+++ b/Source/pvtable.c
@@ -62,8 +62,7 @@ uint64_t generate_hash_key(position_t *pos) {
 }
 
 void clear_hash_table(void) {
-  memset(tt.hash_entry, 0,
-         sizeof(tt_entry_t) * tt.num_of_entries);
+  memset(tt.hash_entry, 0, sizeof(tt_entry_t) * tt.num_of_entries);
 }
 
 // dynamically allocate memory for hash table
@@ -102,12 +101,11 @@ void init_hash_table(uint64_t mb) {
 }
 
 // read hash entry data
-int read_hash_entry(position_t *pos, int alpha, int *move,
-                    int beta, int depth) {
+int read_hash_entry(position_t *pos, int alpha, int *move, int beta,
+                    int depth) {
   // create a TT instance pointer to particular hash entry storing
   // the scoring data for the current board position if available
-  tt_entry_t *hash_entry =
-      &tt.hash_entry[pos->hash_key % tt.num_of_entries];
+  tt_entry_t *hash_entry = &tt.hash_entry[pos->hash_key % tt.num_of_entries];
 
   // make sure we're dealing with the exact position we need
   if (hash_entry->hash_key == pos->hash_key) {
@@ -146,15 +144,17 @@ int read_hash_entry(position_t *pos, int alpha, int *move,
 }
 
 // write hash entry data
-void write_hash_entry(position_t *pos, int score, int depth,
-                      int move, int hash_flag) {
+void write_hash_entry(position_t *pos, int score, int depth, int move,
+                      int hash_flag) {
   // create a TT instance pointer to particular hash entry storing
   // the scoring data for the current board position if available
-  tt_entry_t *hash_entry =
-      &tt.hash_entry[pos->hash_key % tt.num_of_entries];
+  tt_entry_t *hash_entry = &tt.hash_entry[pos->hash_key % tt.num_of_entries];
 
-  if (!(hash_entry->hash_key == pos->hash_key ||
-        (hash_entry->depth <= depth) || hash_entry->flag == hash_flag_exact)) {
+  uint8_t replace = hash_entry->hash_key != pos->hash_key ||
+                    depth + 4 > hash_entry->depth ||
+                    hash_flag == hash_flag_exact;
+
+  if (!replace) {
     return;
   }
 


### PR DESCRIPTION
Elo   | 18.71 +- 8.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2528 W: 701 L: 565 D: 1262
Penta | [27, 254, 594, 334, 55]
https://chess.aronpetkovski.com/test/2226/

Elo   | 22.42 +- 8.44 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1924 W: 486 L: 362 D: 1076
Penta | [14, 170, 471, 292, 15]
https://chess.aronpetkovski.com/test/2227/

bench: 2242645