### PR TITLE
More agressive lmp

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -542,8 +542,6 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
   // number of moves searched in a move list
   int moves_searched = 0;
 
-  int quiet_count = 0;
-
   uint8_t skip_quiets = 0;
 
   // loop over moves within a movelist
@@ -557,7 +555,7 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
 
     // Late Move Pruning
     if (!pv_node && !in_check && quiet &&
-        quiet_count > 6 + 2 * depth * depth) {
+        legal_moves > 6 + 2 * depth * depth) {
       skip_quiets = 1;
     }
 

--- a/Source/search.c
+++ b/Source/search.c
@@ -544,19 +544,21 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
 
   int quiet_count = 0;
 
+  uint8_t skip_quiets = 0;
+
   // loop over moves within a movelist
   for (uint32_t count = 0; count < move_list->count; count++) {
     int list_move = move_list->entry[count].move;
     uint8_t quiet = (get_move_capture(list_move) == 0);
 
-    if (quiet) {
-      quiet_count++;
+    if (skip_quiets && quiet) {
+      continue;
     }
 
     // Late Move Pruning
     if (!pv_node && !in_check && quiet &&
-        quiet_count >= 2 + 1 * depth * depth) {
-      break;
+        quiet_count > 6 + 2 * depth * depth) {
+      skip_quiets = 1;
     }
 
     int move = move_list->entry[count].move;

--- a/Source/search.c
+++ b/Source/search.c
@@ -553,8 +553,9 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
       quiet_count++;
     }
 
+    // Late Move Pruning
     if (!pv_node && !in_check && quiet &&
-        quiet_count > 6 + (depth * depth * 2)) {
+        quiet_count >= 2 + 1 * depth * depth) {
       break;
     }
 


### PR DESCRIPTION
Elo   | 0.71 +- 1.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.06 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 41780 W: 10431 L: 10346 D: 21003
Penta | [470, 5102, 9734, 5041, 543]
https://chess.aronpetkovski.com/test/2272/

passes non reg.

fails to pass gainer bounds. Which is expected given its probably a tiny tiny gainer.

the change is mostly for the future