### PR TITLE
search.c: SEE Move Ordering

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -297,14 +297,13 @@ static inline void score_move(position_t *pos, thread_t *thread,
     // if there's a piece on the target square
     if (bb_piece != NO_PIECE &&
         get_bit(pos->bitboards[bb_piece], get_move_target(move))) {
-      // remove it from corresponding bitboard
       target_piece = bb_piece;
     }
 
     // score move by MVV LVA lookup [source piece][target piece]
     move_entry->score =
-        mvv_lva[get_move_piece(move)][target_piece] + 1000000000;
-    //move_entry->score += SEE(pos, move, -107) ? 1000000000 : -1000000;
+        mvv_lva[get_move_piece(move)][target_piece];
+    move_entry->score += SEE(pos, move, -107) ? 1000000000 : -1000000;
     return;
   }
 


### PR DESCRIPTION
bench: 5131429

Elo   | 20.09 +- 8.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2182 W: 555 L: 429 D: 1198
Penta | [14, 218, 515, 316, 28]
https://chess.aronpetkovski.com/test/2542/