### PR TITLE
search.c: Add tuned parameters

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -30,15 +30,15 @@ extern keys_t keys;
 int LMP_BASE = 6;
 int LMP_MULTIPLIER = 1;
 int RAZOR_DEPTH = 7;
-int RAZOR_MARGIN = 291;
+int RAZOR_MARGIN = 288;
 int RFP_DEPTH = 6;
-int RFP_MARGIN = 105;
-int NMP_BASE_REDUCTION = 6;
+int RFP_MARGIN = 101;
+int NMP_BASE_REDUCTION = 7;
 int NMP_DIVISER = 8;
 int NMP_DEPTH = 1;
 int IIR_DEPTH = 4;
-int SEE_QUIET = 67;
-int SEE_CAPTURE = 32;
+int SEE_QUIET = 66;
+int SEE_CAPTURE = 33;
 int SEE_DEPTH = 10;
 int QS_SEE_THRESHOLD = 7;
 int MO_SEE_THRESHOLD = 107;
@@ -63,7 +63,7 @@ const int mvv_lva[12][12] = {
     {101, 201, 301, 401, 501, 601, 101, 201, 301, 401, 501, 601},
     {100, 200, 300, 400, 500, 600, 100, 200, 300, 400, 500, 600}};
 
-int SEEPieceValues[] = {100, 300, 300, 500, 1200, 0, 0};
+int SEEPieceValues[] = {100, 292, 290, 504, 1176, 0, 0};
 
 /*  =======================
          Move ordering


### PR DESCRIPTION
bench: 4807135

Elo   | 3.73 +- 2.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 17900 W: 4281 L: 4089 D: 9530
Penta | [191, 2087, 4215, 2253, 204]
https://chess.aronpetkovski.com/test/2708/