### PR TITLE
Futility pruning

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -774,7 +774,7 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
     int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
 
     // Futility Pruning
-    if (!root_node && depth <= 5 && !in_check && quiet &&
+    if (!root_node && score > -mate_value && depth <= 5 && !in_check && quiet &&
         static_eval + lmr_depth * 150 + 150 <= alpha) {
       skip_quiets = true;
       continue;

--- a/Source/search.c
+++ b/Source/search.c
@@ -769,6 +769,18 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
       skip_quiets = 1;
     }
 
+    int r = lmr[MIN(63, depth)][MIN(63, legal_moves)];
+    r += !pv_node;
+    int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
+
+    // Futility Pruning
+    if (!root_node && depth <= 5 && !in_check && quiet &&
+        static_eval + lmr_depth * 150 + 150 <= alpha) {
+      skip_quiets = true;
+      continue;
+    }
+
+    // SEE PVS Pruning
     const int see_threshold =
         quiet ? -SEE_QUIET * depth : -SEE_CAPTURE * depth * depth;
     if (depth <= SEE_DEPTH && legal_moves > 0 &&

--- a/Source/search.c
+++ b/Source/search.c
@@ -770,13 +770,11 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
     }
 
     int r = lmr[MIN(63, depth)][MIN(63, legal_moves)];
-    r += !pv_node;
     int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
 
     // Futility Pruning
     if (!root_node && score > -mate_value && lmr_depth <= 5 && !in_check && quiet &&
         static_eval + lmr_depth * 150 + 150 <= alpha) {
-      skip_quiets = true;
       continue;
     }
 

--- a/Source/search.c
+++ b/Source/search.c
@@ -774,7 +774,7 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
     int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
 
     // Futility Pruning
-    if (!root_node && score > -mate_value && depth <= 5 && !in_check && quiet &&
+    if (!root_node && score > -mate_value && lmr_depth <= 5 && !in_check && quiet &&
         static_eval + lmr_depth * 150 + 150 <= alpha) {
       skip_quiets = true;
       continue;


### PR DESCRIPTION
Elo   | 2.68 +- 2.15 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 32808 W: 7751 L: 7498 D: 17559
Penta | [366, 3824, 7743, 4133, 338]
https://chess.aronpetkovski.com/test/2876/