### PR TITLE
search.c: Use tt_score as score if we have tt_hit

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -390,7 +390,7 @@ static inline int quiescence(position_t *pos, thread_t *thread, int alpha,
     return evaluate(pos);
 
   int32_t best_move = 0;
-  int score = 0;
+  int score, best_score = 0;
   int pv_node = beta - alpha > 1;
   int hash_flag = hash_flag_alpha;
   int16_t tt_score = 0;
@@ -412,7 +412,7 @@ static inline int quiescence(position_t *pos, thread_t *thread, int alpha,
   }
 
   // evaluate position
-  score = evaluate(pos);
+  score = best_score = tt_hit ? tt_score : evaluate(pos);
 
   // fail-hard beta cutoff
   if (score >= beta) {
@@ -438,7 +438,6 @@ static inline int quiescence(position_t *pos, thread_t *thread, int alpha,
 
   sort_moves(move_list);
 
-  int best_score = score;
   score = -infinity;
 
   // loop over moves within a movelist


### PR DESCRIPTION
bench: 4698229

Elo   | 7.14 +- 4.52 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6956 W: 1668 L: 1525 D: 3763
Penta | [55, 759, 1726, 864, 74]
https://chess.aronpetkovski.com/test/3062/