### PR TITLE
search.c: Add variation to draw score

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -621,7 +621,7 @@ static inline int negamax(position_t *pos, thread_t *thread, int alpha,
     // if position repetition occurs
     if (is_repetition(pos) || pos->fifty >= 100 || is_material_draw(pos)) {
       // return draw score
-      return 0;
+      return 1 - (thread->nodes & 2);
     }
 
     // we are too deep, hence there's an overflow of arrays relying on max ply


### PR DESCRIPTION
bench: 6782351

unlikely for this to gain at this time control but it passes non reg with some 3elo gain (Small sample size)

Elo   | 2.99 +- 2.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 17772 W: 4294 L: 4141 D: 9337
Penta | [199, 2047, 4260, 2162, 218]
https://chess.aronpetkovski.com/test/3389/