### PR TITLE
Source: Simplify 1 killer move

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -340,13 +340,8 @@ static inline void score_move(position_t *pos, thread_t *thread,
   // score quiet move
   else {
     // score 1st killer move
-    if (thread->killer_moves[0][pos->ply] == move) {
+    if (thread->killer_moves[pos->ply] == move) {
       move_entry->score = 900000000;
-    }
-
-    // score 2nd killer move
-    else if (thread->killer_moves[1][pos->ply] == move) {
-      move_entry->score = 800000000;
     }
 
     // score history move
@@ -984,10 +979,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
           // on quiet moves
           if (quiet) {
             update_all_history_moves(thread, quiet_list, best_move, depth);
-            // store killer moves
-            thread->killer_moves[1][pos->ply] =
-                thread->killer_moves[0][pos->ply];
-            thread->killer_moves[0][pos->ply] = move;
+            thread->killer_moves[pos->ply] = move;
           }
 
           // node (position) fails high

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -64,7 +64,7 @@ typedef struct searchinfo {
   uint64_t starttime;
   uint64_t stoptime;
   int score;
-  int killer_moves[2][max_ply];
+  int killer_moves[max_ply];
   int history_moves[12][64];
   PV_t pv;
   uint8_t depth;


### PR DESCRIPTION
bench: 7373737

Elo   | 0.38 +- 1.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 53772 W: 13134 L: 13075 D: 27563
Penta | [649, 6497, 12504, 6618, 618]
https://chess.aronpetkovski.com/test/3797/