### PR TITLE
search.c: No NMP in pv nodes

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -700,7 +700,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
     }
 
     // null move pruning
-    if (do_nmp && !root_node && static_eval >= beta) {
+    if (do_nmp && !pv_node && static_eval >= beta) {
       int R = NMP_BASE_REDUCTION + depth / NMP_DIVISER;
       R = MIN(R, depth);
       // preserve board state


### PR DESCRIPTION
Elo   | 0.26 +- 1.57 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 62444 W: 15275 L: 15229 D: 31940
Penta | [704, 7536, 14692, 7590, 700]
https://chess.aronpetkovski.com/test/3833/

bench: 7617150