### PR TITLE
search.c: Use static eval in the NMP reduction formula

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -701,7 +701,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
     // null move pruning
     if (do_nmp && !pv_node && static_eval >= beta) {
-      int R = NMP_BASE_REDUCTION + depth / NMP_DIVISER;
+      int R = MIN((static_eval - beta) / 200, 6) + depth / NMP_DIVISER + NMP_BASE_REDUCTION;
       R = MIN(R, depth);
       // preserve board state
       copy_board(pos->bitboards, pos->occupancies, pos->side, pos->enpassant,


### PR DESCRIPTION
Elo   | 3.18 +- 2.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 23948 W: 6037 L: 5818 D: 12093
Penta | [278, 2793, 5629, 2980, 294]
https://chess.aronpetkovski.com/test/3893/

bench: 7404097