### PR TITLE
search.c: Only do NMP if we have non pawns pieces

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -586,6 +586,13 @@ static inline uint8_t is_material_draw(position_t *pos) {
   return 0;
 }
 
+static inline uint8_t only_pawns(position_t *pos) {
+  return !((pos->bitboards[N] | pos->bitboards[n] | pos->bitboards[B] |
+            pos->bitboards[b] | pos->bitboards[R] | pos->bitboards[r] |
+            pos->bitboards[Q] | pos->bitboards[q]) &
+           pos->occupancies[pos->side]);
+}
+
 // negamax alpha beta search
 static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
                           int alpha, int beta, int depth, uint8_t do_nmp,
@@ -700,8 +707,9 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
     }
 
     // null move pruning
-    if (do_nmp && !pv_node && static_eval >= beta) {
-      int R = MIN((static_eval - beta) / 200, 6) + depth / NMP_DIVISER + NMP_BASE_REDUCTION;
+    if (do_nmp && !pv_node && static_eval >= beta && !only_pawns(pos)) {
+      int R = MIN((static_eval - beta) / 200, 6) + depth / NMP_DIVISER +
+              NMP_BASE_REDUCTION;
       R = MIN(R, depth);
       // preserve board state
       copy_board(pos->bitboards, pos->occupancies, pos->side, pos->enpassant,


### PR DESCRIPTION
Elo   | 3.99 +- 3.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 14536 W: 3671 L: 3504 D: 7361
Penta | [164, 1680, 3433, 1807, 184]
https://chess.aronpetkovski.com/test/3898/

bench: 7507145