### PR TITLE
search.c: LMP only if we have non pawn material

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -814,7 +814,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
     // Late Move Pruning
     if (!pv_node && !in_check && quiet &&
-        legal_moves > LMP_BASE + LMP_MULTIPLIER * depth * depth) {
+        legal_moves > LMP_BASE + LMP_MULTIPLIER * depth * depth && !only_pawns(pos)) {
       skip_quiets = 1;
     }
 


### PR DESCRIPTION
Elo   | 3.46 +- 2.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 26088 W: 6512 L: 6252 D: 13324
Penta | [264, 3028, 6236, 3216, 300]
https://chess.aronpetkovski.com/test/3899/

bench: 7507161