### PR TITLE
search.c: Double Extensions

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -854,7 +854,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
       // No move beat tt score so we extend the search
       if (s_score < s_beta) {
-        extensions++;
+        extensions += 1 + (!pv_node && s_score < s_beta);
       }
 
       // Multicut: Singular search failed high so if singular beta beats our


### PR DESCRIPTION
SF style

Elo   | 8.95 +- 5.18 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5046 W: 1262 L: 1132 D: 2652
Penta | [22, 560, 1254, 640, 47]
https://chess.aronpetkovski.com/test/4128/

bench: 8444117