### PR TITLE
search.c: Do not print unfinished asp window search

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1089,6 +1089,10 @@ void *iterative_deepening(void *thread_void) {
     thread->score =
         negamax(pos, thread, ss + 4, alpha, beta, thread->depth, 1, 0);
 
+    if (thread->stopped == 1) {
+      return NULL;
+    }
+
     // We hit an apspiration window cut-off before time ran out and we jumped
     // to another depth with wider search which we didnt finish
     if (thread->score == infinity) {


### PR DESCRIPTION
bench: 8444117

Elo   | 14.05 +- 5.95 (95%)
SPRT  | 1.0+0.01s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 6162 W: 1957 L: 1708 D: 2497
Penta | [154, 662, 1249, 813, 203]
https://chess.aronpetkovski.com/test/4736/