### PR TITLE
search.c: Use mate_score in FP check

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -827,7 +827,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
     int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
 
     // Futility Pruning
-    if (!root_node && score > -mate_value && lmr_depth <= 5 && !in_check &&
+    if (!root_node && score > -mate_score && lmr_depth <= 5 && !in_check &&
         quiet && ss->static_eval + lmr_depth * 150 + 150 <= alpha) {
       continue;
     }


### PR DESCRIPTION
Elo   | 0.69 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.84 (-2.25, 2.89) [0.00, 3.00]
Games | N: 103548 W: 26558 L: 26352 D: 50638
Penta | [1276, 12662, 23770, 12712, 1354]
https://chess.aronpetkovski.com/test/4797/