### PR TITLE
search.c: Add negative extensions

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -876,6 +876,11 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       else if (s_beta >= beta) {
         return s_beta;
       }
+
+      // Negative Extensions
+      else if (tt_score >= beta) {
+        extensions -= 2;
+      }
     }
 
     // preserve board state


### PR DESCRIPTION
Elo   | 5.33 +- 3.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16492 W: 4529 L: 4276 D: 7687
Penta | [267, 1932, 3626, 2123, 298]
https://chess.aronpetkovski.com/test/5159/

bench: 4958603