### PR TITLE
Source: Add capture history

### DIFF
--- a/Source/structs.h
+++ b/Source/structs.h
@@ -68,7 +68,8 @@ typedef struct searchinfo {
   uint64_t stoptime;
   int score;
   int killer_moves[MAX_PLY];
-  int history_moves[12][64][64];
+  int16_t quiet_history[12][64][64];
+  int16_t capture_history[2][64][64];
   PV_t pv;
   uint8_t depth;
   uint8_t timeset;

--- a/Source/uci.c
+++ b/Source/uci.c
@@ -604,7 +604,8 @@ void uci_loop(position_t *pos, thread_t *threads, int argc, char *argv[]) {
       // clear hash table
       clear_hash_table();
       for (int i = 0; i < thread_count; ++i) {
-        memset(threads[i].history_moves, 0, sizeof(threads[i].history_moves));
+        memset(threads[i].quiet_history, 0, sizeof(threads[i].quiet_history));
+        memset(threads[i].capture_history, 0, sizeof(threads[i].capture_history));
       }
     }
     // parse UCI "go" command


### PR DESCRIPTION
Elo   | 3.74 +- 2.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26460 W: 7325 L: 7040 D: 12095
Penta | [515, 3077, 5769, 3346, 523]
https://chess.aronpetkovski.com/test/5193/

bench: 4720446