### PR TITLE
search.c: Add cutnode negative extensions

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -909,6 +909,10 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       else if (tt_score >= beta) {
         extensions -= 2;
       }
+
+      else if (cutnode) {
+        extensions -= 2;
+      }
     }
 
     // preserve board state


### PR DESCRIPTION
Elo   | 3.42 +- 2.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 3.00]
Games | N: 30336 W: 8357 L: 8058 D: 13921
Penta | [509, 3623, 6686, 3760, 590]
https://chess.aronpetkovski.com/test/5189/

bench: 4504346