### PR TITLE
Source: Promotions capthist

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -335,7 +335,8 @@ static inline void score_move(position_t *pos, thread_t *thread,
     // score move by MVV LVA lookup [source piece][target piece]
     move_entry->score = mvv_lva[get_move_piece(move)][target_piece];
     move_entry->score +=
-        thread->capture_history[pos->side][get_move_source(move)][get_move_target(move)];
+        thread->capture_history[pos->side][get_move_source(move)]
+                               [get_move_target(move)];
     move_entry->score +=
         SEE(pos, move, -MO_SEE_THRESHOLD) ? 1000000000 : -1000000;
     move_entry->score += promoted_bonus;
@@ -562,9 +563,8 @@ static inline void update_capture_history(thread_t *thread, int move,
   int clamped_bonus = clamp(is_best_move ? bonus : -bonus, -HISTORY_BONUS_MAX,
                             HISTORY_BONUS_MAX);
   thread->capture_history[thread->pos.side][from][target] +=
-      clamped_bonus -
-      thread->capture_history[thread->pos.side][from][target] *
-          abs(clamped_bonus) / HISTORY_MAX;
+      clamped_bonus - thread->capture_history[thread->pos.side][from][target] *
+                          abs(clamped_bonus) / HISTORY_MAX;
 }
 
 static inline void update_quiet_history_moves(thread_t *thread,
@@ -951,7 +951,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
     if (quiet) {
       add_move(quiet_list, move);
 
-    } else if (get_move_promoted(move) == 0) {
+    } else {
       add_move(capture_list, move);
     }
 

--- a/Source/uci.h
+++ b/Source/uci.h
@@ -3,7 +3,7 @@
 
 #include "structs.h"
 
-#define version "Electra 0.9"
+#define version "Dev"
 
 #define MIN(A, B) ((A) < (B) ? (A) : (B))
 #define MAX(A, B) ((A) > (B) ? (A) : (B))


### PR DESCRIPTION
Elo   | 0.24 +- 1.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -3.03 (-2.94, 2.94) [0.00, 3.00]
Games | N: 112276 W: 27857 L: 27780 D: 56639
Penta | [1231, 13639, 26342, 13674, 1252]
https://chess.aronpetkovski.com/test/5386/

Does not gain but passes non reg

bench: 4514459