### PR TITLE
search.c: Promotions arent quiet moves

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -841,7 +841,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
   // loop over moves within a movelist
   for (uint32_t count = 0; count < move_list->count; count++) {
     int move = move_list->entry[count].move;
-    uint8_t quiet = (get_move_capture(move) == 0);
+    uint8_t quiet = (get_move_capture(move) == 0 && get_move_promoted(move) == 0);
 
     if (move == ss->excluded_move) {
       continue;


### PR DESCRIPTION
Elo   | 0.30 +- 1.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 58356 W: 14288 L: 14237 D: 29831
Penta | [610, 7070, 13812, 7031, 655]
https://chess.aronpetkovski.com/test/5461/

bench: 4505653