### PR TITLE
search.c: No promotion bonus for quiet moves

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -280,7 +280,6 @@ static inline void score_move(position_t *pos, thread_t *thread,
                               move_t *move_entry, int hash_move) {
   int move = move_entry->move;
   uint8_t piece = get_move_promoted(move);
-  uint32_t promoted_bonus = 0;
   if (move == hash_move) {
     move_entry->score = 2000000000;
     return;
@@ -303,21 +302,24 @@ static inline void score_move(position_t *pos, thread_t *thread,
     switch (piece) {
     case q:
     case Q:
-      promoted_bonus = 100000;
+      move_entry->score = 100000;
       break;
     case n:
     case N:
-      promoted_bonus = 90000;
+      move_entry->score = 90000;
       break;
     case r:
     case R:
-      promoted_bonus = -100000;
+      move_entry->score = -100000;
       break;
     case b:
     case B:
-      promoted_bonus = -90000;
+      move_entry->score = -90000;
       break;
     }
+  }
+  else {
+    move_entry->score = 0;
   }
 
   // score capture move
@@ -333,13 +335,12 @@ static inline void score_move(position_t *pos, thread_t *thread,
     }
 
     // score move by MVV LVA lookup [source piece][target piece]
-    move_entry->score = mvv_lva[get_move_piece(move)][target_piece];
+    move_entry->score += mvv_lva[get_move_piece(move)][target_piece];
     move_entry->score +=
         thread->capture_history[pos->side][get_move_source(move)]
                                [get_move_target(move)];
     move_entry->score +=
         SEE(pos, move, -MO_SEE_THRESHOLD) ? 1000000000 : -1000000;
-    move_entry->score += promoted_bonus;
     return;
   }
 
@@ -356,8 +357,6 @@ static inline void score_move(position_t *pos, thread_t *thread,
           thread->quiet_history[get_move_piece(move)][get_move_source(move)]
                                [get_move_target(move)];
     }
-
-    move_entry->score += promoted_bonus;
 
     return;
   }


### PR DESCRIPTION
Elo   | 1.53 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 24906 W: 6185 L: 6075 D: 12646
Penta | [277, 2953, 5906, 3017, 300]
https://chess.aronpetkovski.com/test/5499/

bench: 4375379