### PR TITLE
Source: Bigger capture history

### DIFF
--- a/Source/structs.h
+++ b/Source/structs.h
@@ -85,7 +85,7 @@ typedef struct searchinfo {
   int score;
   int killer_moves[MAX_PLY];
   int16_t quiet_history[12][64][64];
-  int16_t capture_history[2][64][64];
+  int16_t capture_history[12][13][64][64];
   PV_t pv;
   uint8_t depth;
   uint8_t timeset;


### PR DESCRIPTION
Elo   | 3.29 +- 2.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 28060 W: 6913 L: 6647 D: 14500
Penta | [252, 3377, 6544, 3567, 290]
https://chess.aronpetkovski.com/test/5881/

bench: 4233111