### PR TITLE
evaluate.c: Limit 50 move rule to 0.5 as minimum

### DIFF
--- a/Source/evaluate.c
+++ b/Source/evaluate.c
@@ -3,6 +3,7 @@
 #include "enums.h"
 #include "nnue.h"
 #include "structs.h"
+#include "uci.h"
 
 nnue_t nnue_data;
 extern nnue_settings_t nnue_settings;
@@ -17,5 +18,6 @@ int evaluate(position_t *pos, accumulator_t *accumulator) {
 
   eval = eval * (200 + phase) / 256;
   float fifty_move_scaler = (float)((100 - (float)pos->fifty) / 100);
+  fifty_move_scaler = MAX(fifty_move_scaler, 0.5f);
   return (int)(eval * fifty_move_scaler);
 }


### PR DESCRIPTION
Elo   | 2.59 +- 1.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34884 W: 8330 L: 8070 D: 18484
Penta | [254, 3815, 9071, 4021, 281]
https://chess.aronpetkovski.com/test/6135/