### PR TITLE
search.c: Triple extensions

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -906,7 +906,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
       // No move beat tt score so we extend the search
       if (s_score < s_beta) {
-        extensions += 1 + (!pv_node && s_score < s_beta);
+        extensions += 1 + (!pv_node && s_score < s_beta) + (!get_move_capture(move) && s_score + 40 < s_beta);
       }
 
       // Multicut: Singular search failed high so if singular beta beats our


### PR DESCRIPTION
Elo   | 2.68 +- 1.97 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31660 W: 7044 L: 6800 D: 17816
Penta | [88, 3705, 8018, 3913, 106]
https://chess.aronpetkovski.com/test/6370/