### PR TITLE
search.c: 2ply conthist

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -351,7 +351,8 @@ static inline void score_move(position_t *pos, thread_t *thread,
       move_entry->score =
           thread->quiet_history[get_move_piece(move)][get_move_source(move)]
                                [get_move_target(move)] +
-          get_conthist_score(thread, ss - 1, move);
+          get_conthist_score(thread, ss - 1, move) +
+          get_conthist_score(thread, ss - 2, move);
     }
 
     return;
@@ -626,8 +627,11 @@ static inline void update_continuation_history_moves(thread_t *thread,
   for (uint32_t i = 0; i < quiet_moves->count; ++i) {
     if (quiet_moves->entry[i].move == best_move) {
       update_continuation_history(thread, ss - 1, best_move, depth, 1);
+      update_continuation_history(thread, ss - 2, best_move, depth, 1);
     } else {
       update_continuation_history(thread, ss - 1, quiet_moves->entry[i].move,
+                                  depth, 0);
+      update_continuation_history(thread, ss - 2, quiet_moves->entry[i].move,
                                   depth, 0);
     }
   }


### PR DESCRIPTION
Elo   | 6.55 +- 3.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 3.00]
Games | N: 11932 W: 3017 L: 2792 D: 6123
Penta | [95, 1362, 2845, 1551, 113]
https://chess.aronpetkovski.com/test/6451/