### PR TITLE
Promotions on top of move list

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -319,7 +319,7 @@ static inline void score_move(position_t *pos, thread_t *thread,
       move_entry->score = -1000000;
       break;
     }
-    if (SEE(pos, move, -MO_SEE_THRESHOLD)) {
+    if (get_move_capture(move) && SEE(pos, move, -MO_SEE_THRESHOLD)) {
       return;
     } else {
       move_entry->score = -1000000;

--- a/Source/search.c
+++ b/Source/search.c
@@ -303,28 +303,31 @@ static inline void score_move(position_t *pos, thread_t *thread,
     }
   }
 
+
+
   if (piece) {
     switch (piece) {
     case q:
     case Q:
-      move_entry->score = 100000;
+      move_entry->score = 1400000001;
       break;
     case n:
     case N:
-      move_entry->score = 90000;
+      move_entry->score = 1400000000;
       break;
-    case r:
-    case R:
-      move_entry->score = -100000;
-      break;
-    case b:
-    case B:
-      move_entry->score = -90000;
+    default:
+      move_entry->score = -1000000;
       break;
     }
-  } else {
-    move_entry->score = 0;
+    if (SEE(pos, move, -MO_SEE_THRESHOLD)) {
+      return;
+    } else {
+      move_entry->score = -1000000;
+      return;
+    }
   }
+
+  move_entry->score = 0;
 
   // score capture move
   if (get_move_capture(move)) {


### PR DESCRIPTION
Elo   | 4.77 +- 2.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16530 W: 4041 L: 3814 D: 8675
Penta | [133, 1913, 3953, 2126, 140]
https://chess.aronpetkovski.com/test/6461/