### PR TITLE
search.c: Change RFP return

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -692,7 +692,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       // evaluation margin substracted from static evaluation score fails high
       if (static_eval - eval_margin >= beta)
         // evaluation margin substracted from static evaluation score
-        return static_eval - eval_margin;
+        return (static_eval + beta) / 2;
     }
 
     // null move pruning


### PR DESCRIPTION
Elo   | 8.48 +- 4.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8442 W: 2115 L: 1909 D: 4418
Penta | [62, 925, 2058, 1097, 79]
https://chess.aronpetkovski.com/test/6503/