### PR TITLE
Source: Add best move tm

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1101,6 +1101,8 @@ void *iterative_deepening(void *thread_void) {
 
   int pv_table_copy[MAX_PLY][MAX_PLY];
   int pv_length_copy[MAX_PLY];
+  uint16_t prev_best_move = 0;
+  uint8_t best_move_stability = 0;
 
   // iterative deepening
   for (thread->depth = 1; thread->depth <= limits.depth; thread->depth++) {
@@ -1184,6 +1186,18 @@ void *iterative_deepening(void *thread_void) {
       }
 
       window *= ASP_MULTIPLIER;
+    }
+
+    if (thread->index == 0) {
+      if (thread->pv.pv_table[0][0] == prev_best_move) {
+        best_move_stability = MIN(best_move_stability + 1, 4);
+      } else {
+        prev_best_move = thread->pv.pv_table[0][0];
+        best_move_stability = 0;
+      }
+      if (limits.timeset && thread->depth > 7) {
+        scale_time(thread, best_move_stability);
+      }
     }
 
     if (thread->index == 0 && limits.timeset &&

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -97,8 +97,11 @@ typedef struct searchinfo {
 typedef struct limits {
   uint64_t soft_limit;
   uint64_t hard_limit;
+  uint64_t start_time;
   uint64_t time;
   uint32_t inc;
+  uint32_t base_soft;
+  uint32_t max_time;
   uint8_t depth;
   uint8_t timeset;
   uint16_t movestogo;

--- a/Source/uci.c
+++ b/Source/uci.c
@@ -399,6 +399,11 @@ static inline void parse_position(position_t *pos, thread_t *thread,
   }
 }
 
+void scale_time(thread_t *thread, uint8_t best_move_stability) {
+  double bestmove_scale[5] = {2.43, 1.35, 1.09, 0.88, 0.68};
+  limits.soft_limit = MIN(thread->starttime + limits.base_soft * bestmove_scale[best_move_stability], limits.max_time + thread->starttime);
+}
+
 static inline void time_control(position_t *pos, thread_t *threads,
                                 char *line) {
   // reset time control
@@ -462,10 +467,11 @@ static inline void time_control(position_t *pos, thread_t *threads,
         base_time = limits.time * DEF_TIME_MULTIPLIER + limits.inc * DEF_INC_MULTIPLIER;
       }
       
-      int64_t max_time = MAX(1, limits.time * MAX_TIME_MULTIPLIER);
+      limits.max_time = MAX(1, limits.time * MAX_TIME_MULTIPLIER);
+      limits.base_soft = MIN(base_time * SOFT_LIMIT_MULTIPLIER, limits.max_time);
       limits.hard_limit =
-          threads->starttime + MIN(base_time * HARD_LIMIT_MULTIPLIER, max_time);
-      limits.soft_limit = threads->starttime + MIN(base_time * SOFT_LIMIT_MULTIPLIER, max_time);
+          threads->starttime + MIN(base_time * HARD_LIMIT_MULTIPLIER, limits.max_time);
+      limits.soft_limit = threads->starttime + MIN(base_time * SOFT_LIMIT_MULTIPLIER, limits.max_time);
     }
   }
 }

--- a/Source/uci.h
+++ b/Source/uci.h
@@ -15,5 +15,6 @@ extern char promoted_pieces[];
 
 void uci_loop(position_t *pos, thread_t *threads, int argc, char *argv[]);
 void print_move(int move);
+void scale_time(thread_t *thread, uint8_t best_move_stability);
 
 #endif


### PR DESCRIPTION
Elo   | 21.35 +- 6.30 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2998 W: 709 L: 525 D: 1764
Penta | [4, 278, 757, 450, 10]
https://chess.aronpetkovski.com/test/6801/

Elo   | 23.38 +- 6.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 2828 W: 758 L: 568 D: 1502
Penta | [9, 262, 697, 422, 24]
https://chess.aronpetkovski.com/test/6800/

Based on Alexandria implementation