### PR TITLE
Source: Add eval stability TM

### DIFF
--- a/Source/uci.c
+++ b/Source/uci.c
@@ -399,9 +399,10 @@ static inline void parse_position(position_t *pos, thread_t *thread,
   }
 }
 
-void scale_time(thread_t *thread, uint8_t best_move_stability) {
+void scale_time(thread_t *thread, uint8_t best_move_stability, uint8_t eval_stability) {
   double bestmove_scale[5] = {2.43, 1.35, 1.09, 0.88, 0.68};
-  limits.soft_limit = MIN(thread->starttime + limits.base_soft * bestmove_scale[best_move_stability], limits.max_time + thread->starttime);
+  double eval_scale[5] = {1.25, 1.15, 1.00, 0.94, 0.88};
+  limits.soft_limit = MIN(thread->starttime + limits.base_soft * bestmove_scale[best_move_stability] * eval_scale[eval_stability], limits.max_time + thread->starttime);
 }
 
 static inline void time_control(position_t *pos, thread_t *threads,

--- a/Source/uci.h
+++ b/Source/uci.h
@@ -15,6 +15,6 @@ extern char promoted_pieces[];
 
 void uci_loop(position_t *pos, thread_t *threads, int argc, char *argv[]);
 void print_move(int move);
-void scale_time(thread_t *thread, uint8_t best_move_stability);
+void scale_time(thread_t *thread, uint8_t best_move_stability, uint8_t eval_stability);
 
 #endif


### PR DESCRIPTION
Elo   | 2.93 +- 2.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 29286 W: 6506 L: 6259 D: 16521
Penta | [131, 3373, 7413, 3570, 156]
https://chess.aronpetkovski.com/test/6809/