### PR TITLE
search.c: Dont do IIR in excluded search

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -649,7 +649,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
   }
 
   // Internal Iterative Reductions
-  if ((pv_node || cutnode) && depth >= IIR_DEPTH && !tt_move) {
+  if ((pv_node || cutnode) && !ss->excluded_move && depth >= IIR_DEPTH && !tt_move) {
     depth--;
   }
 


### PR DESCRIPTION
Elo   | 2.70 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 32318 W: 7081 L: 6830 D: 18407
Penta | [122, 3710, 8254, 3941, 132]
https://chess.aronpetkovski.com/test/6962/