### PR TITLE
search.c: RFP return mid

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -703,7 +703,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       // evaluation margin substracted from static evaluation score fails high
       if (static_eval - eval_margin >= beta)
         // evaluation margin substracted from static evaluation score
-        return (static_eval + beta) / 2;
+        return beta + (static_eval - beta) / 3;
     }
 
     // null move pruning


### PR DESCRIPTION
Elo   | 2.23 +- 1.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 42700 W: 9273 L: 8999 D: 24428
Penta | [185, 4892, 10920, 5170, 183]
https://chess.aronpetkovski.com/test/6960/