### PR TITLE
search.c: change LMR legal moves

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -955,7 +955,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
     R -= in_check;
     R += cutnode;
 
-    if (depth > 1 && legal_moves > 1) {
+    if (depth > 1 && legal_moves > 2 + 2 * pv_node) {
       R = clamp(R, 1, new_depth);
       int lmr_depth = new_depth - R + 1;
       current_score =


### PR DESCRIPTION
```Elo   | 5.48 +- 3.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 12874 W: 2916 L: 2713 D: 7245
Penta | [50, 1422, 3294, 1617, 54]```
<https://chess.aronpetkovski.com/test/7358/>