### PR TITLE
search.c: Reduce less if TT move depth is equal or better than depth

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -768,6 +768,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       R -= ss->history_score / (quiet ? LMR_QUIET_HIST_DIV : LMR_CAPT_HIST_DIV);
       R -= in_check;
       R += cutnode;
+      R -= tt_depth >= depth;
       R = clamp(R, 1, new_depth);
       current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
                                new_depth - R + 1, 1, 1);


### PR DESCRIPTION
Elo   | 1.69 +- 1.37 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 69810 W: 15769 L: 15430 D: 38611
Penta | [336, 8294, 17343, 8559, 373]
<https://chess.aronpetkovski.com/test/7410/>