### PR TITLE
search.c: Refactor the way check extensions are done

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -461,13 +461,8 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
                                         : __builtin_ctzll(pos->bitboards[k]),
                                     pos->side ^ 1);
 
-  // increase search depth if the king has been exposed into a check
-  if (in_check) {
-    depth++;
-  }
-
   // recursion escape condition
-  if (depth <= 0) {
+  if (!in_check && depth <= 0) {
     // run quiescence search
     return quiescence(pos, thread, ss, alpha, beta);
   }
@@ -765,6 +760,10 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
     prefetch_hash_entry(pos->hash_key);
 
     uint8_t needs_full_search = 0;
+
+    if (in_check) {
+      extensions++;
+    }
 
     // PVS & LMR
     int new_depth = depth + extensions - 1;


### PR DESCRIPTION
Elo   | 1.01 +- 2.05 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 30730 W: 6998 L: 6909 D: 16823
Penta | [154, 3603, 7771, 3674, 163]
<https://chess.aronpetkovski.com/test/7543/>