### PR TITLE
search.c: Do more NE if move is not pvnode

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -722,7 +722,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
       // Negative Extensions
       else if (tt_score >= beta) {
-        extensions -= 2;
+        extensions -= 2 + 1 * !pv_node;
       }
 
       else if (cutnode) {


### PR DESCRIPTION
Elo   | 2.16 +- 1.70 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 44846 W: 10220 L: 9941 D: 24685
Penta | [224, 5190, 11340, 5421, 248]
<https://chess.aronpetkovski.com/test/7909/>

This was thought by me but sadly not original as it was already in SF and even simplified away...