### PR TITLE
search.c: DE in pv_node with margin

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -705,7 +705,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       // No move beat tt score so we extend the search
       if (s_score < s_beta) {
         extensions++;
-        if (!pv_node && s_score < s_beta) {
+        if (s_score < s_beta - 2 * pv_node) {
           extensions++;
         }
         if (!get_move_capture(move) && s_score + SE_TRIPLE_MARGIN < s_beta) {


### PR DESCRIPTION
Elo   | 3.37 +- 2.27 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21856 W: 4584 L: 4372 D: 12900
Penta | [41, 2380, 5869, 2602, 36]
<https://chess.aronpetkovski.com/test/7911/>