### PR TITLE
Source: Find PV nodes correctly not by a hack

### DIFF
--- a/Source/enums.h
+++ b/Source/enums.h
@@ -86,4 +86,6 @@ enum { opening, endgame, middlegame };
 // piece types
 enum { PAWN, KNIGHT, BISHOP, ROOK, QUEEN, KING };
 
+enum { NON_PV, PV_NODE };
+
 #endif


### PR DESCRIPTION
Elo   | 1.17 +- 2.17 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 27044 W: 5996 L: 5905 D: 15143
Penta | [135, 3142, 6867, 3253, 125]
<https://chess.aronpetkovski.com/test/8054/>

Should also gain but non reg is easier to test.