### PR TITLE
search.c: Reduce less if TT move was PV node

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -799,6 +799,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       R -= in_check * LMR_IN_CHECK;
       R += cutnode * LMR_CUTNODE;
       R -= (tt_depth >= depth) * LMR_TT_DEPTH;
+      R -= tt_was_pv * 1024;
       R = clamp(R / 1024, 1, new_depth);
       current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
                                new_depth - R + 1, 1, NON_PV);


### PR DESCRIPTION
Elo   | 0.90 +- 1.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.57 (-2.25, 2.89) [0.00, 3.00]
Games | N: 103744 W: 22925 L: 22655 D: 58164
Penta | [453, 12369, 25992, 12571, 487]
<https://chess.aronpetkovski.com/test/8085/>

Not finished but at this point i would say that its clear gainer and Obsidian Dev agrees