### PR TITLE
search.c: Store tt_was_pv into TT instead of pv_node

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -298,7 +298,6 @@ static inline int quiescence(position_t *pos, thread_t *thread,
   // evaluate position
   score = best_score =
       tt_hit ? tt_score : evaluate(pos, &thread->accumulator[pos->ply]);
-  ;
 
   // fail-hard beta cutoff
   if (score >= beta) {
@@ -411,7 +410,7 @@ static inline int quiescence(position_t *pos, thread_t *thread,
     hash_flag = HASH_FLAG_UPPER_BOUND;
   }
 
-  write_hash_entry(pos, best_score, 0, best_move, hash_flag, pv_node);
+  write_hash_entry(pos, best_score, 0, best_move, hash_flag, tt_was_pv);
 
   return best_score;
 }
@@ -895,7 +894,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       hash_flag = HASH_FLAG_UPPER_BOUND;
     }
     // store hash entry with the score equal to alpha
-    write_hash_entry(pos, best_score, depth, best_move, hash_flag, pv_node);
+    write_hash_entry(pos, best_score, depth, best_move, hash_flag, tt_was_pv);
   }
 
   // node (position) fails low


### PR DESCRIPTION
Elo   | 3.38 +- 3.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 11916 W: 2657 L: 2541 D: 6718
Penta | [43, 1378, 3014, 1466, 57]
<https://chess.aronpetkovski.com/test/8103/>