### PR TITLE
search.c: Do more LMP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -664,8 +664,8 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
     // Late Move Pruning
     if (!pv_node && !in_check && quiet &&
-        legal_moves >
-            LMP_BASE + LMP_MULTIPLIER * depth * depth / (2 - improving) &&
+        legal_moves >=
+            LMP_BASE + LMP_MULTIPLIER * depth * depth / (3 - improving) &&
         !only_pawns(pos)) {
       skip_quiets = 1;
     }


### PR DESCRIPTION
Elo   | 2.76 +- 2.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31676 W: 7241 L: 6989 D: 17446
Penta | [160, 3719, 7866, 3895, 198]
<https://chess.aronpetkovski.com/test/8110/>