### PR TITLE
search.c: LMP in check

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -663,7 +663,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
                                      [get_move_target(move)];
 
     // Late Move Pruning
-    if (!pv_node && !in_check && quiet &&
+    if (!pv_node && quiet &&
         legal_moves >=
             LMP_BASE + LMP_MULTIPLIER * depth * depth / (3 - improving) &&
         !only_pawns(pos)) {


### PR DESCRIPTION
Elo   | 1.86 +- 1.50 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 57942 W: 13181 L: 12870 D: 31891
Penta | [293, 6776, 14521, 7089, 292]
<https://chess.aronpetkovski.com/test/8118/>