### PR TITLE
search.c: lmr reductions more if not PV node for lmr_depth

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -674,6 +674,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
     }
 
     int r = lmr[quiet][MIN(63, depth)][MIN(63, moves_seen)];
+    r += !pv_node;
     int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
 
     // Futility Pruning


### PR DESCRIPTION
Elo   | 1.03 +- 1.59 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.67 (-2.25, 2.89) [0.00, 3.00]
Games | N: 43744 W: 9145 L: 9015 D: 25584
Penta | [59, 4891, 11863, 4979, 80]
<https://chess.aronpetkovski.com/test/8119/>

Running for WAY too long with always positive LLR. Lets just merge.