### PR TITLE
search.c: Do not extend if our ply is > 2*rootdepth

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -695,7 +695,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
     // A rather simple idea that if our TT move is accurate we run a reduced
     // search to see if we can beat this score. If not we extend the TT move
     // search
-    if (!root_node && depth >= SE_DEPTH && move == tt_move &&
+    if (pos->ply < thread->depth * 2 && !root_node && depth >= SE_DEPTH && move == tt_move &&
         !ss->excluded_move && tt_depth >= depth - SE_DEPTH_REDUCTION &&
         tt_flag != HASH_FLAG_UPPER_BOUND && abs(tt_score) < MATE_SCORE) {
       const int s_beta = tt_score - depth;


### PR DESCRIPTION
Elo   | 0.06 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 78746 W: 17836 L: 17823 D: 43087
Penta | [366, 8975, 20696, 8952, 384]
<https://chess.aronpetkovski.com/test/8145/>