### PR TITLE
search.c: Fail with average in standpat


### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -311,6 +311,9 @@ static inline int quiescence(position_t *pos, thread_t *thread,
 
   // fail-hard beta cutoff
   if (best_score >= beta) {
+    if (abs(best_score) < MATE_SCORE && abs(beta) < MATE_SCORE) {
+      best_score = (best_score + beta) / 2;
+    }
     // node (position) fails high
     return best_score;
   }
@@ -1087,7 +1090,7 @@ void *iterative_deepening(void *thread_void) {
                           : (average_score + thread->score) / 2;
 
       if (thread->pv.pv_table[0][0] == prev_best_move) {
-        best_move_stability = MIN(best_move_stability + 1, 4);
+        best_move_stability = MIN(best_move_stability + 1, 18);
       } else {
         prev_best_move = thread->pv.pv_table[0][0];
         best_move_stability = 0;

--- a/Source/search.c
+++ b/Source/search.c
@@ -1090,7 +1090,7 @@ void *iterative_deepening(void *thread_void) {
                           : (average_score + thread->score) / 2;
 
       if (thread->pv.pv_table[0][0] == prev_best_move) {
-        best_move_stability = MIN(best_move_stability + 1, 18);
+        best_move_stability = MIN(best_move_stability + 1, 4);
       } else {
         prev_best_move = thread->pv.pv_table[0][0];
         best_move_stability = 0;


### PR DESCRIPTION
Elo   | 2.43 +- 1.85 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36564 W: 8087 L: 7831 D: 20646
Penta | [133, 4243, 9284, 4479, 143]
<https://chess.aronpetkovski.com/test/8267/>