### PR TITLE
search.c: TT depth IIR


### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -526,7 +526,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
   // Internal Iterative Reductions
   if ((pv_node || cutnode) && !ss->excluded_move && depth >= IIR_DEPTH &&
-      !tt_move) {
+      (!tt_move || tt_depth < depth - IIR_DEPTH)) {
     depth--;
   }
 


### PR DESCRIPTION
Elo   | 2.26 +- 1.74 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 40974 W: 9037 L: 8771 D: 23166
Penta | [147, 4773, 10396, 5009, 162]
<https://chess.aronpetkovski.com/test/8272/>