### PR TITLE
Static eval tt

### DIFF
--- a/Source/bitboards.h
+++ b/Source/bitboards.h
@@ -4,8 +4,8 @@
 #include <assert.h>
 #include <stdint.h>
 
-#define NO_SCORE 32001
 #define INF 32000
+#define NO_SCORE -INF
 #define MATE_VALUE 31000
 #define MATE_SCORE 30000
 

--- a/Source/search.c
+++ b/Source/search.c
@@ -313,8 +313,6 @@ static inline int quiescence(position_t *pos, thread_t *thread,
   uint8_t tt_was_pv = pv_node;
 
   tt_entry_t tt_entry;
-  //A hack so compiler doesnt tell us it can be used uninitialized
-  tt_entry.static_eval = NO_SCORE;
 
   tt_hit = read_hash_entry(pos, &tt_entry);
 

--- a/Source/search.c
+++ b/Source/search.c
@@ -307,17 +307,21 @@ static inline int quiescence(position_t *pos, thread_t *thread,
   int score = NO_SCORE, best_score = NO_SCORE;
   int raw_static_eval = NO_SCORE;
   int16_t tt_score = NO_SCORE;
+  int16_t tt_static_eval = NO_SCORE;
   uint8_t tt_hit = 0;
   uint8_t tt_flag = HASH_FLAG_EXACT;
   uint8_t tt_was_pv = pv_node;
 
   tt_entry_t tt_entry;
+  //A hack so compiler doesnt tell us it can be used uninitialized
+  tt_entry.static_eval = NO_SCORE;
 
   tt_hit = read_hash_entry(pos, &tt_entry);
 
   if (tt_hit) {
     tt_was_pv |= tt_entry.tt_pv;
     tt_score = tt_entry.score;
+    tt_static_eval = tt_entry.static_eval;
     tt_flag = tt_entry.flag;
   }
 
@@ -327,7 +331,7 @@ static inline int quiescence(position_t *pos, thread_t *thread,
     return tt_score;
   }
 
-  raw_static_eval = evaluate(pos, &thread->accumulator[pos->ply]);
+  raw_static_eval = tt_static_eval != NO_SCORE ? tt_static_eval : evaluate(pos, &thread->accumulator[pos->ply]);
   best_score = ss->static_eval =
       adjust_static_eval(thread, pos, raw_static_eval);
 
@@ -448,7 +452,8 @@ static inline int quiescence(position_t *pos, thread_t *thread,
     hash_flag = HASH_FLAG_UPPER_BOUND;
   }
 
-  write_hash_entry(pos, best_score, 0, best_move, hash_flag, tt_was_pv);
+  write_hash_entry(pos, best_score, raw_static_eval, 0, best_move, hash_flag,
+                   tt_was_pv);
 
   return best_score;
 }
@@ -467,6 +472,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
   uint16_t tt_move = 0;
   int16_t tt_score = NO_SCORE;
+  int16_t tt_static_eval = NO_SCORE;
   uint8_t tt_hit = 0;
   uint8_t tt_depth = 0;
   uint8_t tt_flag = HASH_FLAG_EXACT;
@@ -522,6 +528,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
   if (tt_hit) {
     tt_was_pv |= tt_entry.tt_pv;
     tt_score = tt_entry.score;
+    tt_static_eval = tt_entry.static_eval;
     tt_depth = tt_entry.depth;
     tt_flag = tt_entry.flag;
     tt_move = tt_entry.move;
@@ -543,7 +550,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
   if (in_check) {
     static_eval = ss->static_eval = NO_SCORE;
   } else if (!ss->excluded_move) {
-    raw_static_eval = evaluate(pos, &thread->accumulator[pos->ply]);
+    raw_static_eval = tt_static_eval != NO_SCORE ? tt_static_eval : evaluate(pos, &thread->accumulator[pos->ply]);
 
     // adjust static eval with corrhist
     static_eval = ss->static_eval =
@@ -948,7 +955,7 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
       hash_flag = HASH_FLAG_UPPER_BOUND;
     }
     // store hash entry with the score equal to alpha
-    write_hash_entry(pos, best_score, depth, best_move, hash_flag, tt_was_pv);
+    write_hash_entry(pos, best_score, raw_static_eval, depth, best_move, hash_flag, tt_was_pv);
 
     if (!in_check && (!best_move || !(is_move_promotion(best_move) ||
                                       get_move_capture(best_move)))) {

--- a/Source/search.c
+++ b/Source/search.c
@@ -465,8 +465,8 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
 
   // variable to store current move's score (from the static evaluation
   // perspective)
-  int current_score = -NO_SCORE, static_eval = -NO_SCORE;
-  int raw_static_eval = -NO_SCORE;
+  int current_score = NO_SCORE, static_eval = NO_SCORE;
+  int raw_static_eval = NO_SCORE;
 
   uint16_t tt_move = 0;
   int16_t tt_score = NO_SCORE;
@@ -672,8 +672,8 @@ static inline int negamax(position_t *pos, thread_t *thread, searchstack_t *ss,
   // generate moves
   generate_moves(pos, move_list);
 
-  int best_score = -INF;
-  current_score = -INF;
+  int best_score = NO_SCORE;
+  current_score = NO_SCORE;
 
   int best_move = 0;
   for (uint32_t count = 0; count < move_list->count; count++) {

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -27,6 +27,7 @@ typedef struct tt_entry {
   uint32_t hash_key; // "almost" unique chess position identifier
   uint16_t move;
   int16_t score; // score (alpha/beta/PV)
+  int16_t static_eval;
   uint8_t depth; // current search depth
   uint8_t flag : 2;  // flag the type of node (fail-low/fail-high/PV)
   uint8_t tt_pv : 1;

--- a/Source/transposition.c
+++ b/Source/transposition.c
@@ -116,9 +116,10 @@ void init_hash_table(uint64_t mb) {
 }
 
 uint8_t can_use_score(int alpha, int beta, int tt_score, uint8_t flag) {
-  if (tt_score != NO_SCORE && ((flag == HASH_FLAG_EXACT) ||
-      ((flag == HASH_FLAG_UPPER_BOUND) && (tt_score <= alpha)) ||
-      ((flag == HASH_FLAG_LOWER_BOUND) && (tt_score >= beta)))) {
+  if (tt_score != NO_SCORE &&
+      ((flag == HASH_FLAG_EXACT) ||
+       ((flag == HASH_FLAG_UPPER_BOUND) && (tt_score <= alpha)) ||
+       ((flag == HASH_FLAG_LOWER_BOUND) && (tt_score >= beta)))) {
     return 1;
   }
   return 0;
@@ -149,8 +150,9 @@ uint8_t read_hash_entry(position_t *pos, tt_entry_t *tt_entry) {
 }
 
 // write hash entry data
-void write_hash_entry(position_t *pos, int16_t score, uint8_t depth,
-                      uint16_t move, uint8_t hash_flag, uint8_t tt_pv) {
+void write_hash_entry(position_t *pos, int16_t score, int16_t static_eval,
+                      uint8_t depth, uint16_t move, uint8_t hash_flag,
+                      uint8_t tt_pv) {
   // create a TT instance pointer to particular hash entry storing
   // the scoring data for the current board position if available
   tt_entry_t *hash_entry = &tt.hash_entry[get_hash_index(pos->hash_keys.hash_key)];
@@ -173,6 +175,7 @@ void write_hash_entry(position_t *pos, int16_t score, uint8_t depth,
   // write hash entry data
   hash_entry->hash_key = get_hash_low_bits(pos->hash_keys.hash_key);
   hash_entry->score = score;
+  hash_entry->static_eval = static_eval;
   hash_entry->flag = hash_flag;
   hash_entry->tt_pv = tt_pv;
   hash_entry->depth = depth;

--- a/Source/transposition.c
+++ b/Source/transposition.c
@@ -139,6 +139,7 @@ uint8_t read_hash_entry(position_t *pos, tt_entry_t *tt_entry) {
 
     tt_entry->move = hash_entry->move;
     tt_entry->score = score;
+    tt_entry->static_eval = hash_entry->static_eval;
     tt_entry->depth = hash_entry->depth;
     tt_entry->flag = hash_entry->flag;
     tt_entry->tt_pv = hash_entry->tt_pv;

--- a/Source/transposition.h
+++ b/Source/transposition.h
@@ -21,8 +21,9 @@ void clear_hash_table(void);
 void prefetch_hash_entry(uint64_t hash_key);
 uint8_t can_use_score(int alpha, int beta, int tt_score, uint8_t flag);
 uint8_t read_hash_entry(position_t *pos, tt_entry_t *tt_entry);
-void write_hash_entry(position_t *pos, int16_t score, uint8_t depth,
-                      uint16_t move, uint8_t hash_flag, uint8_t tt_pv);
+void write_hash_entry(position_t *pos, int16_t score, int16_t static_eval,
+                      uint8_t depth, uint16_t move, uint8_t hash_flag,
+                      uint8_t tt_pv);
 void init_hash_table(uint64_t mb);
 uint64_t generate_hash_key(position_t *pos);
 int hash_full(void);


### PR DESCRIPTION
```Elo   | 4.29 +- 2.75 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 3.09 (-2.25, 2.89) [0.00, 3.00]
Games | N: 21766 W: 5839 L: 5570 D: 10357
Penta | [287, 2554, 4957, 2773, 312]```
<https://chess.aronpetkovski.com/test/8491/>