### PR TITLE
search.c: Fix stack in QS

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -411,7 +411,7 @@ static inline int quiescence(position_t *pos, thread_t *thread,
     prefetch_hash_entry(pos->hash_keys.hash_key);
 
     // score current move
-    score = -quiescence(pos, thread, ss, -beta, -alpha, pv_node);
+    score = -quiescence(pos, thread, ss + 1, -beta, -alpha, pv_node);
 
     // decrement ply
     pos->ply--;


### PR DESCRIPTION
Elo   | 3.59 +- 3.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 11526 W: 2788 L: 2669 D: 6069
Penta | [69, 1334, 2848, 1433, 79]
<https://chess.aronpetkovski.com/test/8584/>