### PR TITLE
search.c: SEE history score modifier

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -736,7 +736,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread, searchstack_t *
 
     // SEE PVS Pruning
     if (depth <= SEE_DEPTH && moves_seen > 0 &&
-        !SEE(pos, move, SEE_MARGIN[depth][quiet]))
+        !SEE(pos, move, SEE_MARGIN[depth][quiet] - ss->history_score / 60))
       continue;
 
     int extensions = 0;


### PR DESCRIPTION
Elo   | 1.09 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.84 (-2.25, 2.89) [0.00, 3.00]
Games | N: 68048 W: 16381 L: 16167 D: 35500
Penta | [515, 7990, 16814, 8176, 529]
<https://chess.aronpetkovski.com/test/8640/>

As Gabe would say. Screw this. Im merging.