### PR TITLE
search.c: Skip moves with bad SEE score in QS

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -366,8 +366,13 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
     uint16_t move = move_list->entry[count].move;
     uint8_t quiet = !(get_move_capture(move) || is_move_promotion(move));
 
-    if (best_score > -MATE_SCORE && quiets_seen > 0) {
-      break;
+    if (best_score > -MATE_SCORE) {
+      if (quiets_seen > 0) {
+        break;
+      }
+      if (!SEE(pos, move, -QS_SEE_THRESHOLD)) {
+        continue;
+      }
     }
 
     // preserve board state


### PR DESCRIPTION
Elo   | 37.48 +- 8.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 1880 W: 551 L: 349 D: 980
Penta | [10, 152, 439, 304, 35]
<https://chess.aronpetkovski.com/test/8760/>