### PR TITLE
search.c: QS FP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -362,6 +362,8 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
 
   sort_moves(move_list);
 
+  int16_t futility_score = best_score + 150;
+
   for (uint32_t count = 0; count < move_list->count; count++) {
     uint16_t move = move_list->entry[count].move;
     uint8_t quiet = !(get_move_capture(move) || is_move_promotion(move));
@@ -369,6 +371,10 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
     if (best_score > -MATE_SCORE) {
       if (quiets_seen > 0) {
         break;
+      }
+      if (!in_check && futility_score <= alpha && !SEE(pos, move, 1)) {
+        best_score = MAX(best_score, futility_score);
+        continue;
       }
       if (!SEE(pos, move, -QS_SEE_THRESHOLD)) {
         continue;


### PR DESCRIPTION
Elo   | 1.92 +- 1.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 58000 W: 14195 L: 13875 D: 29930
Penta | [402, 6855, 14211, 7085, 447]
<https://chess.aronpetkovski.com/test/8761/>