### PR TITLE
search.c: Do not extend reduced_depth

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -863,7 +863,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread, searchstack_t *
     R -= (tt_depth >= depth) * LMR_TT_DEPTH;
     R -= tt_was_pv * LMR_TT_PV;
     R = R / 1024;
-    int reduced_depth = MAX(1, MIN(new_depth - R + 1, new_depth));
+    int reduced_depth = MAX(1, MIN(new_depth - R, new_depth));
 
     if (depth >= 2 && moves_seen > 2 + 2 * pv_node) {
       ss->reduction = R;


### PR DESCRIPTION
Elo   | 1.11 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 28850 W: 6711 L: 6619 D: 15520
Penta | [165, 3455, 7109, 3515, 181]
<https://chess.aronpetkovski.com/test/8805/>

Finally we get rid of it