### PR TITLE
search.c: tt_pv failed low lmr reduction

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -856,6 +856,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread, searchstack_t *
     R += cutnode * LMR_CUTNODE;
     R -= (tt_depth >= depth) * LMR_TT_DEPTH;
     R -= tt_was_pv * LMR_TT_PV;
+    R += (tt_was_pv && tt_hit && tt_entry->score <= alpha) * 1024;
     R = R / 1024;
     int reduced_depth = MAX(1, MIN(new_depth - R, new_depth));
 


### PR DESCRIPTION
Elo   | 2.63 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33780 W: 7753 L: 7497 D: 18530
Penta | [173, 3923, 8440, 4183, 171]
<https://chess.aronpetkovski.com/test/8922/>