### PR TITLE
Source: tt_pv on stack for excluded moves

### DIFF
--- a/Source/structs.h
+++ b/Source/structs.h
@@ -134,6 +134,7 @@ typedef struct searchstack {
   int history_score;
   uint8_t piece;
   uint8_t null_move;
+  uint8_t tt_pv;
 } searchstack_t;
 
 typedef struct nnue_settings {


### PR DESCRIPTION
Elo   | 0.19 +- 1.41 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 64306 W: 14368 L: 14333 D: 35605
Penta | [304, 7603, 16301, 7644, 301]
<https://chess.aronpetkovski.com/test/8984/>