### PR TITLE
search.c: Use ss->eval in NMP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -620,9 +620,9 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     }
 
     // null move pruning
-    if (!ss->null_move && ss->static_eval >= beta && depth >= 3 &&
+    if (!ss->null_move && ss->eval >= beta && depth >= 3 &&
         !only_pawns(pos)) {
-      int R = MIN((ss->static_eval - beta) / NMP_RED_DIVISER, NMP_RED_MIN) +
+      int R = MIN((ss->eval - beta) / NMP_RED_DIVISER, NMP_RED_MIN) +
               depth / NMP_DIVISER + NMP_BASE_REDUCTION;
       R = MIN(R, depth);
       // preserve board state


### PR DESCRIPTION
Elo   | 5.42 +- 3.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 13084 W: 3030 L: 2826 D: 7228
Penta | [48, 1470, 3310, 1658, 56]
https://furybench.com/test/143/