### PR TITLE
search.c: Use 1ply conthist in search quiet hist score

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -735,7 +735,8 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
         quiet
             ? thread
                   ->quiet_history[pos->mailbox[get_move_source(move)]]
-                                 [get_move_source(move)][get_move_target(move)]
+                                 [get_move_source(move)][get_move_target(move)] +
+              get_conthist_score(thread, ss - 1, move)
             : thread->capture_history[pos->mailbox[get_move_source(move)]]
                                      [pos->mailbox[get_move_target(move)]]
                                      [get_move_source(move)]


### PR DESCRIPTION
Elo   | 2.87 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29552 W: 6695 L: 6451 D: 16406
Penta | [112, 3450, 7442, 3626, 146]
https://furybench.com/test/188/