### PR TITLE
search.c: use 2ply conthist in search hist score

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -736,7 +736,8 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
             ? thread
                   ->quiet_history[pos->mailbox[get_move_source(move)]]
                                  [get_move_source(move)][get_move_target(move)] +
-              get_conthist_score(thread, ss - 1, move)
+              get_conthist_score(thread, ss - 1, move) +
+              get_conthist_score(thread, ss - 2, move)
             : thread->capture_history[pos->mailbox[get_move_source(move)]]
                                      [pos->mailbox[get_move_target(move)]]
                                      [get_move_source(move)]


### PR DESCRIPTION
Elo   | 1.01 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.83 (-2.25, 2.89) [0.00, 3.00]
Games | N: 84254 W: 19399 L: 19154 D: 45701
Penta | [458, 9998, 20991, 10201, 479]
https://furybench.com/test/203/

as mr gabe would say. just merge it already.

the chance of this losing elo crazily low and it probably scales...