### PR TITLE
search.c: Use stack static eval for improving

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -586,7 +586,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
   uint8_t opponent_worsening = 0;
 
   if ((ss - 2)->static_eval != NO_SCORE) {
-    improving = static_eval > (ss - 2)->static_eval;
+    improving = ss->static_eval > (ss - 2)->static_eval;
   }
   if (!in_check) {
     opponent_worsening = ss->static_eval + (ss - 1)->static_eval > 1;


### PR DESCRIPTION
Elo   | 1.75 +- 2.48 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 20822 W: 4710 L: 4605 D: 11507
Penta | [104, 2421, 5243, 2552, 91]
https://furybench.com/test/230/

i can finally do this and it doesnt lose elo but seems to be actually good.