### PR TITLE
search.c: LMR do deeper and shallower

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -892,6 +892,9 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       ss->reduction = 0;
 
       if (current_score > alpha && R != 0) {
+        new_depth += (current_score > best_score + 35 + 2 * new_depth);
+        new_depth -= (current_score < best_score + 6);
+
         current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
                                  new_depth, !cutnode, NON_PV);
       }


### PR DESCRIPTION
Elo   | 2.80 +- 2.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31312 W: 7211 L: 6959 D: 17142
Penta | [144, 3618, 7891, 3848, 155]
https://furybench.com/test/260/