### PR TITLE
search.c: More SE depth reduction

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -784,7 +784,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
         tt_depth >= depth - SE_DEPTH_REDUCTION &&
         tt_flag != HASH_FLAG_UPPER_BOUND && abs(tt_score) < MATE_SCORE) {
       const int s_beta = tt_score - depth;
-      const int s_depth = (depth - 1) / 2;
+      const int s_depth = 3 * (depth - 1) / 8;
 
       position_t pos_copy = *pos;
 


### PR DESCRIPTION
Elo   | 0.78 +- 0.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -0.12 (-2.25, 2.89) [0.00, 3.00]
Games | N: 143210 W: 32893 L: 32572 D: 77745
Penta | [767, 16962, 35804, 17327, 745]
https://furybench.com/test/269/

unfinished but its clearly not losing elo and probably gaining