### PR TITLE
search.c: Use improving_factor in improving LMP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -118,7 +118,7 @@ void init_reductions(void) {
             pow(depth, LMP_MARGIN_WORSENING_POWER); // non-improving
     LMP_MARGIN[depth][1] =
         LMP_MARGIN_IMPROVING_BASE +
-        LMP_MARGIN_WORSENING_FACTOR *
+        LMP_MARGIN_IMPROVING_FACTOR *
             pow(depth, LMP_MARGIN_IMPROVING_POWER); // improving
     for (int move = 0; move < 256; move++) {
       if (move == 0 || depth == 0) {


### PR DESCRIPTION
Elo   | 3.02 +- 3.18 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 13330 W: 3244 L: 3128 D: 6958
Penta | [77, 1559, 3292, 1645, 92]
https://furybench.com/test/469/