### PR TITLE
search.c: Simplify check extensions

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -891,10 +891,6 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
     prefetch_hash_entry(pos->hash_keys.hash_key);
 
-    if (in_check) {
-      extensions++;
-    }
-
     uint64_t nodes_before_search = thread->nodes;
 
     // PVS & LMR


### PR DESCRIPTION
Elo   | 7.16 +- 4.55 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 5922 W: 1407 L: 1285 D: 3230
Penta | [11, 665, 1502, 757, 26]
https://furybench.com/test/656/