### PR TITLE
search.c: Limit depth to 0 after qsearch check

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -565,6 +565,9 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     return quiescence(pos, thread, ss, alpha, beta, pv_node);
   }
 
+  // In case depth is -1 we have to make it 0
+  depth = MAX(0, depth);
+
   tt_entry_t *tt_entry = read_hash_entry(pos, &tt_hit);
 
   if (tt_hit) {


### PR DESCRIPTION
Elo   | 0.50 +- 1.61 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 44918 W: 10059 L: 9995 D: 24864
Penta | [130, 5122, 11886, 5196, 125]
https://furybench.com/test/679/