### PR TITLE
search.c: Add constant margin offset to RFP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -632,7 +632,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     }
     // Reverse Futility Pruning
     if (depth <= RFP_DEPTH &&
-        ss->eval >= beta + RFP_MARGIN * depth - 59 * improving) {
+        ss->eval >= beta + RFP_MARGIN * depth - 59 * improving + 25) {
       // evaluation margin substracted from static evaluation score
       return beta + (ss->eval - beta) / 3;
     }
@@ -902,7 +902,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     R = R / 1024;
     int reduced_depth = MAX(1, MIN(new_depth - R, new_depth));
 
-    //LMR
+    // LMR
     if (depth >= 2 && moves_seen > 2 + 2 * pv_node) {
       ss->reduction = R;
       current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
@@ -919,7 +919,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
                                    new_depth, !cutnode, NON_PV);
         }
       }
-    // Full Depth Search
+      // Full Depth Search
     } else if (!pv_node || moves_seen > 1) {
       current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
                                new_depth, !cutnode, NON_PV);


### PR DESCRIPTION
Elo   | 4.06 +- 2.59 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18384 W: 4208 L: 3993 D: 10183
Penta | [64, 2072, 4707, 2283, 66]
https://furybench.com/test/879/