### PR TITLE
search.c: static eval NMP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -651,6 +651,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
     // null move pruning
     if (!ss->null_move && depth >= NMP_DEPTH && ss->eval >= beta &&
+        ss->static_eval >= beta - 20 * depth + 180 &&
         ss->eval >= ss->static_eval && !only_pawns(pos)) {
       int R = MIN((ss->eval - beta) / NMP_RED_DIVISER, NMP_RED_MIN) +
               depth / NMP_DIVISER + NMP_BASE_REDUCTION;


### PR DESCRIPTION
Elo   | 1.12 +- 1.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 1.23 (-2.25, 2.89) [0.00, 3.00]
Games | N: 74742 W: 16869 L: 16629 D: 41244
Penta | [298, 8660, 19193, 8944, 276]
https://furybench.com/test/909/

as mr obsidian would say. Merge it... 