### PR TITLE
Rfp opponent worsening

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -644,7 +644,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     }
     // Reverse Futility Pruning
     if (depth <= RFP_DEPTH &&
-        ss->eval >= beta + RFP_MARGIN * depth - 59 * improving + 25) {
+        ss->eval >= beta + RFP_MARGIN * depth - 59 * improving + 25 - 12 * opponent_worsening) {
       // evaluation margin substracted from static evaluation score
       return beta + (ss->eval - beta) / 3;
     }

--- a/Source/search.c
+++ b/Source/search.c
@@ -651,6 +651,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
     // null move pruning
     if (!ss->null_move && depth >= NMP_DEPTH && ss->eval >= beta &&
+        ss->static_eval >= beta - 20 * depth + 180 &&
         ss->eval >= ss->static_eval && !only_pawns(pos)) {
       int R = MIN((ss->eval - beta) / NMP_RED_DIVISER, NMP_RED_MIN) +
               depth / NMP_DIVISER + NMP_BASE_REDUCTION;


### PR DESCRIPTION
Elo   | 1.85 +- 1.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 55338 W: 12435 L: 12140 D: 30763
Penta | [173, 6418, 14246, 6605, 227]
https://furybench.com/test/950/