### PR TITLE
search.c: Do not limit fail high count

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1112,7 +1112,7 @@ static inline uint8_t aspiration_windows(thread_t *thread, position_t *pos,
     else if (thread->score >= beta) {
       beta = MIN(INF, beta + window);
 
-      if (alpha < 2000 && fail_high_count < 2) {
+      if (alpha < 2000) {
         ++fail_high_count;
       }
     } else {


### PR DESCRIPTION
Elo   | 4.42 +- 3.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 8734 W: 1911 L: 1800 D: 5023
Penta | [20, 898, 2415, 1019, 15]
https://furybench.com/test/970/