### PR TITLE
Source: Handle enpassant correctly in capture history

### DIFF
--- a/Source/history.c
+++ b/Source/history.c
@@ -144,11 +144,16 @@ static inline void update_capture_history(thread_t *thread, int move,
                                           int bonus) {
   int from = get_move_source(move);
   int target = get_move_target(move);
+  int prev_target_piece =
+      get_move_enpassant(move) == 0 ? thread->pos.mailbox[get_move_target(move)]
+      : thread->pos.side ? thread->pos.mailbox[get_move_target(move) - 8]
+                         : thread->pos.mailbox[get_move_target(move) + 8];
+
   thread->capture_history[thread->pos.mailbox[from]]
-                         [thread->pos.mailbox[target]][from][target] +=
+                         [prev_target_piece][from][target] +=
       bonus -
       thread->capture_history[thread->pos.mailbox[from]]
-                             [thread->pos.mailbox[target]][from][target] *
+                             [prev_target_piece][from][target] *
           abs(bonus) / HISTORY_MAX;
 }
 

--- a/Source/search.c
+++ b/Source/search.c
@@ -209,14 +209,10 @@ static inline void score_move(position_t *pos, thread_t *thread,
   // score capture move
   if (get_move_capture(move)) {
     // init target piece
-    int target_piece = P;
-
-    uint8_t bb_piece = pos->mailbox[get_move_target(move)];
-    // if there's a piece on the target square
-    if (bb_piece != NO_PIECE &&
-        get_bit(pos->bitboards[bb_piece], get_move_target(move))) {
-      target_piece = bb_piece;
-    }
+    int target_piece = get_move_enpassant(move) == 0
+                           ? pos->mailbox[get_move_target(move)]
+                       : pos->side ? pos->mailbox[get_move_target(move) - 8]
+                                   : pos->mailbox[get_move_target(move) + 8];
 
     // score move by MVV LVA lookup [source piece][target piece]
     move_entry->score +=


### PR DESCRIPTION
Elo   | 0.12 +- 1.30 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 72100 W: 15990 L: 15966 D: 40144
Penta | [233, 8500, 18561, 8522, 234]
https://furybench.com/test/1009/