### PR TITLE
search.c: Reduce less if the node is tt_pv and cutnode

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -909,6 +909,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     R -= (tt_depth >= depth) * LMR_TT_DEPTH;
     R -= ss->tt_pv * LMR_TT_PV;
     R += (ss->tt_pv && tt_hit && tt_score <= alpha) * LMR_TT_SCORE;
+    R -= (ss->tt_pv && cutnode) * 768;
     R = R / 1024;
     int reduced_depth = MAX(1, MIN(new_depth - R, new_depth));
 


### PR DESCRIPTION
Elo   | 0.99 +- 1.28 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 0.77 (-2.25, 2.89) [0.00, 3.00]
Games | N: 75016 W: 16819 L: 16606 D: 41591
Penta | [288, 8738, 19243, 8951, 288]
https://furybench.com/test/1022/

probably a yellow at worst. merge