### PR TITLE
search.c: Use improving lmp if static eval is bigger than beta

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -772,7 +772,8 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
                                        [get_move_target(move)];
 
     // Late Move Pruning
-    if (!pv_node && quiet && moves_seen >= LMP_MARGIN[depth][improving] &&
+    if (!pv_node && quiet &&
+        moves_seen >= LMP_MARGIN[depth][improving || ss->static_eval >= beta] &&
         !only_pawns(pos)) {
       skip_quiets = 1;
     }


### PR DESCRIPTION
Elo   | 3.47 +- 2.34 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 22712 W: 5157 L: 4930 D: 12625
Penta | [67, 2638, 5735, 2833, 83]
https://furybench.com/test/1038/