### PR TITLE
uci.c: Simplify TM and improve it

### DIFF
--- a/Source/uci.c
+++ b/Source/uci.c
@@ -465,14 +465,10 @@ static inline void time_control(position_t *pos, thread_t *threads,
       }
 
       limits.max_time = MAX(1, limits.time * MAX_TIME_MULTIPLIER);
+      limits.hard_limit = threads->starttime + limits.max_time;
       limits.base_soft =
           MIN(base_time * SOFT_LIMIT_MULTIPLIER, limits.max_time);
-      limits.hard_limit =
-          threads->starttime +
-          MIN(base_time * HARD_LIMIT_MULTIPLIER, limits.max_time);
-      limits.soft_limit =
-          threads->starttime +
-          MIN(base_time * SOFT_LIMIT_MULTIPLIER, limits.max_time);
+      limits.soft_limit = threads->starttime + limits.base_soft;
     }
   }
 }
@@ -651,7 +647,7 @@ void uci_loop(position_t *pos, thread_t *threads, int argc, char *argv[]) {
              nnue_settings.nnue_file);
       printf("option name Clear Hash type button\n");
       // SPSA
-      //print_spsa_table_uci();
+      // print_spsa_table_uci();
       // uciok
       printf("uciok\n");
     } else if (strncmp(input, "spsa", 4) == 0) {


### PR DESCRIPTION
This should fix the time losses

Loses elo at STC:
Elo   | -5.63 +- 3.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | -2.28 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7038 W: 1591 L: 1705 D: 3742
Penta | [23, 806, 1971, 700, 19]
https://furybench.com/test/1514/

Seems to be a maybe slight gainer at LTC:
Elo   | 0.99 +- 1.56 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=128MB
LLR   | 0.67 (-2.25, 2.89) [0.00, 3.00]
Games | N: 37690 W: 8133 L: 8026 D: 21531
Penta | [27, 3584, 11520, 3683, 31]
https://furybench.com/test/1515/

Thus it scales and we merging :)