### PR TITLE
search.c: Adjust FP margin with history

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -800,7 +800,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     // Futility Pruning
     if (!root_node && current_score > -MATE_SCORE && lmr_depth <= FP_DEPTH &&
         !in_check && quiet &&
-        ss->static_eval + lmr_depth * FP_MULTIPLIER + FP_ADDITION <= alpha) {
+        ss->static_eval + lmr_depth * FP_MULTIPLIER + FP_ADDITION + ss->history_score / 32 <= alpha) {
       skip_quiets = 1;
       continue;
     }


### PR DESCRIPTION
Elo   | 4.15 +- 2.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17900 W: 4185 L: 3971 D: 9744
Penta | [64, 2030, 4558, 2224, 74]
https://furybench.com/test/1546/