### PR TITLE
search.c: Save eval to TT early

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -616,6 +616,11 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
             ? tt_static_eval
             : evaluate(thread, pos, &thread->accumulator[pos->ply]);
 
+    if (!tt_hit) {
+      write_hash_entry(tt_entry, pos, NO_SCORE, raw_static_eval, 0, 0,
+                       HASH_FLAG_NONE, ss->tt_pv);
+    }
+
     // adjust static eval with corrhist
     static_eval = ss->static_eval =
         adjust_static_eval(thread, pos, raw_static_eval);
@@ -800,7 +805,9 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     // Futility Pruning
     if (!root_node && current_score > -MATE_SCORE && lmr_depth <= FP_DEPTH &&
         !in_check && quiet &&
-        ss->static_eval + lmr_depth * FP_MULTIPLIER + FP_ADDITION + ss->history_score / 32 <= alpha) {
+        ss->static_eval + lmr_depth * FP_MULTIPLIER + FP_ADDITION +
+                ss->history_score / 32 <=
+            alpha) {
       skip_quiets = 1;
       continue;
     }


### PR DESCRIPTION
Elo   | 7.97 +- 4.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.39 (-2.25, 2.89) [0.00, 3.00]
Games | N: 6936 W: 1667 L: 1508 D: 3761
Penta | [13, 790, 1719, 917, 29]
https://furybench.com/test/1550/

merging before time cause it passes 0 5 bounds with 0 issues.