### PR TITLE
Source: Simplify killer moves fully

### DIFF
--- a/Source/structs.h
+++ b/Source/structs.h
@@ -107,7 +107,6 @@ typedef struct searchinfo {
   PV_t pv;
   uint16_t index;
   int16_t score;
-  uint16_t killer_moves[MAX_PLY];
   int16_t correction_history[2][16384];
   int16_t quiet_history[2][6][64][64];
   int16_t continuation_history[12][64][12][64];


### PR DESCRIPTION
Elo   | 4.28 +- 3.65 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 9488 W: 2236 L: 2119 D: 5133
Penta | [44, 1055, 2432, 1166, 47]
https://furybench.com/test/1588/