### PR TITLE
search.c: Disable RFP if we are in ttpv node

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -651,7 +651,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       ++depth;
     }
     // Reverse Futility Pruning
-    if (depth <= RFP_DEPTH &&
+    if (!ss->tt_pv && depth <= RFP_DEPTH &&
         ss->eval >= beta + RFP_BASE_MARGIN + RFP_MARGIN * depth -
                         RFP_IMPROVING * improving -
                         RFP_OPP_WORSENING * opponent_worsening) {


### PR DESCRIPTION
Elo   | 1.79 +- 1.43 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 59336 W: 13865 L: 13560 D: 31911
Penta | [188, 6857, 15305, 7098, 220]
https://furybench.com/test/1865/