### PR TITLE
search.c: Use hash_flag in corrhist updates

### DIFF
--- a/.zed/debug.json
+++ b/.zed/debug.json
@@ -1,0 +1,13 @@
+[
+  {
+    "label": "Debug native binary",
+    "build": {
+      "command": "make",
+      "args": ["-j8"],
+      "cwd": "$ZED_WORKTREE_ROOT"
+    },
+    "program": "$ZED_WORKTREE_ROOT/Quanticade",
+    "request": "launch",
+    "adapter": "CodeLLDB"
+  }
+]

--- a/Source/search.c
+++ b/Source/search.c
@@ -795,7 +795,6 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     int r = lmr[quiet][MIN(63, depth)][MIN(63, moves_seen)];
     r += !pv_node;
     int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
-
     // Futility Pruning
     if (!root_node && current_score > -MATE_SCORE && lmr_depth <= FP_DEPTH &&
         !in_check && quiet &&
@@ -1042,7 +1041,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     if (!in_check && (!best_move || !(is_move_promotion(best_move) ||
                                       get_move_capture(best_move)))) {
       update_pawn_corrhist(thread, pos, raw_static_eval, best_score, depth,
-                           tt_flag);
+                           hash_flag);
     }
   }
 


### PR DESCRIPTION
Elo   | 3.58 +- 3.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 11056 W: 2635 L: 2521 D: 5900
Penta | [35, 1257, 2830, 1371, 35]
https://furybench.com/test/1886/