### PR TITLE
Source: Move fifty move rule scaling to static eval adjusting

### DIFF
--- a/Source/evaluate.c
+++ b/Source/evaluate.c
@@ -18,9 +18,6 @@ int16_t evaluate(thread_t *thread, position_t *pos, accumulator_t *accumulator) 
               10 * popcount(pos->bitboards[q] | pos->bitboards[Q]);
 
   eval = eval * (200 + phase) / 256;
-  float fifty_move_scaler = (float)((100 - (float)pos->fifty) / 100);
-  fifty_move_scaler = MAX(fifty_move_scaler, 0.5f);
-  int final_eval = eval * fifty_move_scaler;
-  final_eval = clamp(final_eval, -MATE_SCORE + 1, MATE_SCORE - 1);
-  return (int16_t)final_eval;
+  eval = clamp(eval, -MATE_SCORE + 1, MATE_SCORE - 1);
+  return (int16_t)eval;
 }

--- a/Source/history.c
+++ b/Source/history.c
@@ -168,6 +168,8 @@ uint8_t static_eval_within_bounds(int16_t static_eval, int16_t score,
 
 int16_t adjust_static_eval(thread_t *thread, position_t *pos,
                            int16_t static_eval) {
+  const float fifty_move_scaler = (float)((200 - (float)pos->fifty) / 200);
+  static_eval = static_eval * fifty_move_scaler;
   const int pawn_correction =
       thread->correction_history[pos->side][pos->hash_keys.pawn_key & 16383] *
       PAWN_CORR_HISTORY_MULTIPLIER;


### PR DESCRIPTION
Elo   | 1.53 +- 2.36 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 22254 W: 5189 L: 5091 D: 11974
Penta | [61, 2666, 5602, 2710, 88]
https://furybench.com/test/2001/