### PR TITLE
search.c: Increase NMP base reduction to 5

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -34,7 +34,7 @@ extern keys_t keys;
 int RAZOR_DEPTH = 7;
 int RFP_DEPTH = 7;
 int FP_DEPTH = 10;
-int NMP_BASE_REDUCTION = 4;
+int NMP_BASE_REDUCTION = 5;
 int NMP_DIVISER = 3;
 int NMP_RED_MIN = 3;
 int IIR_DEPTH = 4;


### PR DESCRIPTION
Elo   | 1.75 +- 1.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 2.50]
Games | N: 63448 W: 14851 L: 14532 D: 34065
Penta | [119, 7326, 16504, 7667, 108]
https://furybench.com/test/2537/