### PR TITLE
search.c: Adjust fail high return score in main search

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1081,6 +1081,11 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     }
   }
 
+  if (best_score >= beta && abs(best_score) < MATE_SCORE &&
+      abs(beta) < MATE_SCORE) {
+    best_score = (best_score * depth + beta) / (depth + 1);
+  }
+
   // node (position) fails low
   return best_score;
 }


### PR DESCRIPTION
Elo   | 1.64 +- 1.33 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 70028 W: 16612 L: 16282 D: 37134
Penta | [206, 8282, 17781, 8466, 279]
https://furybench.com/test/2567/