### PR TITLE
Source: Update quiet history on TT cutoff

### DIFF
--- a/Source/history.c
+++ b/Source/history.c
@@ -222,7 +222,7 @@ void update_corrhist(thread_t *thread, position_t *pos, int16_t static_eval,
           bonus);
 }
 
-static inline void update_quiet_history(thread_t *thread, position_t *pos,
+void update_quiet_history(thread_t *thread, position_t *pos,
                                         searchstack_t *ss, int move,
                                         int bonus) {
   int target = get_move_target(move);

--- a/Source/history.h
+++ b/Source/history.h
@@ -7,8 +7,8 @@ uint64_t generate_pawn_key(position_t *pos);
 uint64_t generate_white_non_pawn_key(position_t *pos);
 uint64_t generate_black_non_pawn_key(position_t *pos);
 
-void update_corrhist(thread_t *thread, position_t *pos, int16_t static_eval, int16_t score,
-                          uint8_t depth, uint8_t tt_flag);
+void update_corrhist(thread_t *thread, position_t *pos, int16_t static_eval,
+                     int16_t score, uint8_t depth, uint8_t tt_flag);
 int16_t adjust_static_eval(thread_t *thread, position_t *pos,
                            int16_t static_eval);
 void update_capture_history_moves(thread_t *thread, position_t *pos,
@@ -19,5 +19,8 @@ int16_t get_conthist_score(thread_t *thread, position_t *pos, searchstack_t *ss,
 void update_quiet_histories(thread_t *thread, position_t *pos,
                             searchstack_t *ss, moves *quiet_moves,
                             int best_move, uint8_t depth);
+
+void update_quiet_history(thread_t *thread, position_t *pos, searchstack_t *ss,
+                          int move, int bonus);
 
 #endif

--- a/Source/search.c
+++ b/Source/search.c
@@ -622,6 +622,12 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
   // we can return early from search
   if (!ss->excluded_move && !pv_node && tt_depth >= depth &&
       can_use_score(alpha, beta, tt_score, tt_flag)) {
+    if (tt_move != 0 &&
+        !(is_move_promotion(tt_move) || get_move_capture(tt_move)) &&
+        tt_score >= beta) {
+      int16_t bonus = MIN(1270, (133 * depth - 65));
+      update_quiet_history(thread, pos, ss, tt_move, bonus);
+    }
     return tt_score;
   }
 

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -113,7 +113,7 @@ typedef struct searchinfo {
   int16_t correction_history[2][16384];
   int16_t b_non_pawn_correction_history[2][16384];
   int16_t w_non_pawn_correction_history[2][16384];
-  int16_t quiet_history[2][6][64][64][2][2];
+  int16_t quiet_history[2][7][64][64][2][2];
   int16_t continuation_history[12][64][12][64];
   int16_t capture_history[12][13][64][64];
   int16_t pawn_history[2048][12][64];


### PR DESCRIPTION
Elo   | 0.61 +- 0.97 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -0.17 (-2.25, 2.89) [0.00, 2.50]
Games | N: 128018 W: 30029 L: 29806 D: 68183
Penta | [339, 15118, 32927, 15231, 394]
https://furybench.com/test/2542/

I say good enough and with tune it has to be good