### PR TITLE
search.c: Allow extensions in LMR for PV nodes

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -979,7 +979,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       ss->reduction = R;
 
       R = R / 1024;
-      int reduced_depth = MAX(1, MIN(new_depth - R, new_depth));
+      int reduced_depth = MAX(1, MIN(new_depth - R, new_depth)) + pv_node;
 
       current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
                                reduced_depth, 1, NON_PV);


### PR DESCRIPTION
Elo   | 1.73 +- 1.38 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.25, 2.89) [0.00, 3.00]
Games | N: 62090 W: 14453 L: 14144 D: 33493
Penta | [126, 7214, 16080, 7475, 150]
https://furybench.com/test/2578/