### PR TITLE
search.c: Do hindsight depth modifications before premove pruning check

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -677,19 +677,19 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     return 0;
   }
 
+  if ((ss - 1)->reduction >= 3072 && !opponent_worsening) {
+    ++depth;
+  }
+
+  if (depth >= 2 && (ss - 1)->reduction >= 2048 && (ss - 1)->eval != NO_SCORE &&
+      ss->static_eval + (ss - 1)->eval > 96) {
+    --depth;
+  }
+
   // moves seen counter
   uint16_t moves_seen = 0;
 
   if (!pv_node && !in_check && !ss->excluded_move) {
-    if ((ss - 1)->reduction >= 3072 && !opponent_worsening) {
-      ++depth;
-    }
-
-    if (depth >= 2 && (ss - 1)->reduction >= 2048 && (ss - 1)->eval != NO_SCORE &&
-        ss->static_eval + (ss - 1)->eval > 96) {
-      --depth;
-    }
-
     // Reverse Futility Pruning
     if (!ss->tt_pv && depth <= RFP_DEPTH &&
         ss->eval >= beta + RFP_BASE_MARGIN + RFP_MARGIN * depth -


### PR DESCRIPTION
Elo   | 0.89 +- 1.97 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 32332 W: 7827 L: 7744 D: 16761
Penta | [132, 3798, 8209, 3909, 118]
https://furybench.com/test/2605/