### PR TITLE
Initial depth lmp

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -771,7 +771,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     }
 
     if (depth <= RAZOR_DEPTH &&
-        ss->static_eval + RAZOR_MARGIN * initial_depth < alpha) {
+        ss->static_eval + RAZOR_MARGIN * depth < alpha) {
       const int16_t razor_score =
           quiescence(pos, thread, ss, alpha, beta, NON_PV);
       if (razor_score <= alpha) {
@@ -833,7 +833,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
     // Late Move Pruning
     if (!pv_node && quiet &&
-        moves_seen >= LMP_MARGIN[depth][improving || ss->static_eval >= beta] &&
+        moves_seen >= LMP_MARGIN[initial_depth][improving || ss->static_eval >= beta] &&
         !only_pawns(pos)) {
       skip_quiets = 1;
     }


### PR DESCRIPTION
Elo   | 0.85 +- 1.19 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 0.37 (-2.25, 2.89) [0.00, 3.00]
Games | N: 83710 W: 19551 L: 19347 D: 44812
Penta | [163, 9864, 21625, 10012, 191]
https://furybench.com/test/2577/