### PR TITLE
Source: Implement cutoff cnt reductions

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -675,6 +675,8 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     opponent_worsening = ss->static_eval + (ss - 1)->static_eval > 1;
   }
 
+  (ss + 2)->cutoff_cnt = 0;
+
   // Check on time
   if (check_time(thread)) {
     stop_threads(thread, thread_count);
@@ -980,6 +982,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       R += (ss->tt_pv && tt_hit && tt_score <= alpha) * LMR_TT_SCORE;
       R -= (ss->tt_pv && cutnode) * LMR_TT_PV_CUTNODE;
       R -= stm_in_check(pos) * LMR_IN_CHECK;
+      R += (ss->cutoff_cnt > 3) * 1024;
 
       ss->reduction = R;
 
@@ -1063,6 +1066,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
           update_capture_history_moves(thread, pos, capture_list, best_move,
                                        depth);
+          ss->cutoff_cnt++;
           break;
         }
       }
@@ -1231,6 +1235,7 @@ void *iterative_deepening(void *thread_void) {
       ss[i].null_move = 0;
       ss[i].reduction = 0;
       ss[i].tt_pv = 0;
+      ss[i].cutoff_cnt = 0;
     }
 
     calculate_threats(pos, ss + 7);

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -155,6 +155,7 @@ typedef struct searchthread {
 
 typedef struct searchstack {
   threats_t threats;
+  int32_t cutoff_cnt;
   uint16_t excluded_move;
   uint16_t move;
   int16_t static_eval;


### PR DESCRIPTION
Elo   | 0.53 +- 1.41 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -0.69 (-2.25, 2.89) [0.00, 3.00]
Games | N: 60420 W: 14013 L: 13921 D: 32486
Penta | [149, 7188, 15429, 7310, 134]
https://furybench.com/test/2620/