### PR TITLE
search.c: Try improving LMR again...

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -980,6 +980,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       R += (ss->tt_pv && tt_hit && tt_score <= alpha) * LMR_TT_SCORE;
       R -= (ss->tt_pv && cutnode) * LMR_TT_PV_CUTNODE;
       R -= stm_in_check(pos) * LMR_IN_CHECK;
+      R -= 1024 * improving;
 
       ss->reduction = R;
 


### PR DESCRIPTION
Elo   | 2.28 +- 2.22 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 1.79 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23804 W: 5603 L: 5447 D: 12754
Penta | [38, 2770, 6141, 2904, 49]
https://furybench.com/test/2619/

Passes nonreg and is close enough. Done with this BS.