### PR TITLE
Source: Add NMP verification search

### DIFF
--- a/Source/structs.h
+++ b/Source/structs.h
@@ -107,6 +107,7 @@ typedef struct searchinfo {
   position_t pos;
   uint64_t repetition_table[2000];
   uint32_t repetition_index;
+  uint32_t nmp_min_ply;
   PV_t pv;
   uint16_t index;
   int16_t score;


### PR DESCRIPTION
Elo   | 1.96 +- 2.54 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 17918 W: 4161 L: 4060 D: 9697
Penta | [26, 2070, 4678, 2147, 38]
https://furybench.com/test/2685/