### PR TITLE
search.c: Add QS FP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -414,6 +414,8 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
     alpha = MAX(alpha, best_score);
   }
 
+  const int16_t futility_score = best_score + 100;
+
   // create move list instance
   moves move_list[1];
   moves capture_list[1];
@@ -452,6 +454,12 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
       if (move_index >= 3) {
         continue;
       }
+    }
+
+    if (!in_check && get_move_capture(move) && futility_score <= alpha &&
+        !SEE(pos, move, 1)) {
+      best_score = MAX(best_score, futility_score);
+      continue;
     }
 
     // preserve board state


### PR DESCRIPTION
Elo   | 4.09 +- 2.57 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 17512 W: 4090 L: 3884 D: 9538
Penta | [29, 1971, 4552, 2173, 31]
https://furybench.com/test/2711/