### PR TITLE
Source: Simplify piece index in butterfly history

### DIFF
--- a/Source/history.c
+++ b/Source/history.c
@@ -244,19 +244,16 @@ void update_corrhist(thread_t *thread, position_t *pos, int16_t static_eval,
           bonus);
 }
 
-void update_quiet_history(thread_t *thread, position_t *pos,
-                                        searchstack_t *ss, int move,
-                                        int bonus) {
+void update_quiet_history(thread_t *thread, position_t *pos, searchstack_t *ss,
+                          int move, int bonus) {
   int target = get_move_target(move);
   int source = get_move_source(move);
-  const uint8_t cpiece = pos->mailbox[source];
-  const uint8_t piece = cpiece > 5 ? cpiece - 6 : cpiece;
-  thread->quiet_history[pos->side][piece][source][target][is_square_threatened(
+  thread->quiet_history[pos->side][source][target][is_square_threatened(
       ss, source)][is_square_threatened(ss, target)] +=
-      bonus - thread->quiet_history[pos->side][piece][source][target]
-                                   [is_square_threatened(ss, source)]
-                                   [is_square_threatened(ss, target)] *
-                  abs(bonus) / HISTORY_MAX;
+      bonus -
+      thread->quiet_history[pos->side][source][target][is_square_threatened(
+          ss, source)][is_square_threatened(ss, target)] *
+          abs(bonus) / HISTORY_MAX;
 }
 
 static inline void update_capture_history(thread_t *thread, position_t *pos,

--- a/Source/search.c
+++ b/Source/search.c
@@ -252,11 +252,9 @@ static inline void score_move(position_t *pos, thread_t *thread,
   else {
     // score history move
     move_entry->score =
-        thread
-            ->quiet_history[pos->side][pos->mailbox[get_move_source(move)] % 6]
-                           [get_move_source(move)][get_move_target(move)]
-                           [is_square_threatened(ss, get_move_source(move))]
-                           [is_square_threatened(ss, get_move_target(move))] +
+        thread->quiet_history[pos->side][get_move_source(move)][get_move_target(
+            move)][is_square_threatened(ss, get_move_source(move))]
+                             [is_square_threatened(ss, get_move_target(move))] +
         get_conthist_score(thread, pos, ss - 1, move) +
         get_conthist_score(thread, pos, ss - 2, move) +
         get_conthist_score(thread, pos, ss - 4, move) +
@@ -858,17 +856,17 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     }
 
     ss->history_score =
-        quiet ? thread->quiet_history
-                        [pos->side][pos->mailbox[get_move_source(move)] % 6]
-                        [get_move_source(move)][get_move_target(move)]
-                        [is_square_threatened(ss, get_move_source(move))]
-                        [is_square_threatened(ss, get_move_target(move))] +
-                    get_conthist_score(thread, pos, ss - 1, move) +
-                    get_conthist_score(thread, pos, ss - 2, move)
-              : thread->capture_history[pos->mailbox[get_move_source(move)]]
-                                       [pos->mailbox[get_move_target(move)]]
-                                       [get_move_source(move)]
-                                       [get_move_target(move)];
+        quiet
+            ? thread->quiet_history
+                      [pos->side][get_move_source(move)][get_move_target(move)]
+                      [is_square_threatened(ss, get_move_source(move))]
+                      [is_square_threatened(ss, get_move_target(move))] +
+                  get_conthist_score(thread, pos, ss - 1, move) +
+                  get_conthist_score(thread, pos, ss - 2, move)
+            : thread->capture_history[pos->mailbox[get_move_source(move)]]
+                                     [pos->mailbox[get_move_target(move)]]
+                                     [get_move_source(move)]
+                                     [get_move_target(move)];
 
     // Late Move Pruning
     if (!pv_node && quiet &&

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -114,7 +114,7 @@ typedef struct searchinfo {
   int16_t correction_history[2][16384];
   int16_t b_non_pawn_correction_history[2][16384];
   int16_t w_non_pawn_correction_history[2][16384];
-  int16_t quiet_history[2][7][64][64][2][2];
+  int16_t quiet_history[2][64][64][2][2];
   int16_t continuation_history[12][64][12][64];
   int16_t capture_history[12][13][64][64];
   int16_t pawn_history[2048][12][64];


### PR DESCRIPTION
Elo   | 2.63 +- 1.94 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32108 W: 7553 L: 7310 D: 17245
Penta | [82, 3718, 8229, 3925, 100]
https://furybench.com/test/2834/