### PR TITLE
search.c: Allow extensions in LMR if in cutnode

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1020,7 +1020,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       ss->reduction = R;
 
       R = R / 1024;
-      int reduced_depth = MAX(1, MIN(new_depth - R, new_depth)) + pv_node;
+      int reduced_depth = MAX(1, MIN(new_depth - R, new_depth + cutnode)) + pv_node;
 
       current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
                                reduced_depth, 1, NON_PV);


### PR DESCRIPTION

Elo   | 1.89 +- 1.52 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 54300 W: 12918 L: 12622 D: 28760
Penta | [213, 6303, 13828, 6587, 219]
https://furybench.com/test/2864/