### PR TITLE
search.c: Add MVV value to noisy history score

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -866,7 +866,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
             : thread->capture_history[pos->mailbox[get_move_source(move)]]
                                      [pos->mailbox[get_move_target(move)]]
                                      [get_move_source(move)]
-                                     [get_move_target(move)];
+                                     [get_move_target(move)] + mvv[pos->mailbox[get_move_target(move)] % 6];
 
     // Late Move Pruning
     if (!pv_node && quiet &&


### PR DESCRIPTION
Elo   | 2.49 +- 1.87 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34430 W: 8172 L: 7925 D: 18333
Penta | [88, 4003, 8800, 4222, 102]
https://furybench.com/test/2882/