### PR TITLE
movegen.c: Speedup movegen

### DIFF
--- a/Source/movegen.c
+++ b/Source/movegen.c
@@ -493,9 +493,15 @@ void generate_moves(position_t *pos, moves *move_list) {
 
   // define current piece's bitboard copy & its attacks
   uint64_t bitboard, attacks;
+  uint8_t start = P, end = K;
+
+  if (pos->side == black) {
+    start = p;
+    end = k;
+  }
 
   // loop over all the bitboards
-  for (uint8_t piece = P; piece <= k; piece++) {
+  for (uint8_t piece = start; piece <= end; piece++) {
     // init piece bitboard copy
     bitboard = pos->bitboards[piece];
 
@@ -942,9 +948,15 @@ void generate_noisy(position_t *pos, moves *move_list) {
 
   // define current piece's bitboard copy & its attacks
   uint64_t bitboard, attacks;
+  uint8_t start = P, end = K;
+
+  if (pos->side == black) {
+    start = p;
+    end = k;
+  }
 
   // loop over all the bitboards
-  for (uint8_t piece = P; piece <= k; piece++) {
+  for (uint8_t piece = start; piece <= end; piece++) {
     // init piece bitboard copy
     bitboard = pos->bitboards[piece];
 


### PR DESCRIPTION
Elo   | 2.46 +- 1.84 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 34612 W: 8574 L: 8329 D: 17709
Penta | [164, 3562, 9662, 3701, 217]
https://furybench.com/test/3022/