### PR TITLE
search.c: Use static eval when checking if we can use tt_score

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -399,7 +399,7 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
             : evaluate(thread, pos, &thread->accumulator[pos->ply]);
     ss->static_eval = adjust_static_eval(thread, pos, raw_static_eval);
 
-    if (tt_hit && can_use_score(best_score, best_score, tt_score, tt_flag)) {
+    if (tt_hit && can_use_score(ss->static_eval, ss->static_eval, tt_score, tt_flag)) {
       best_score = tt_score;
     } else {
       best_score = ss->static_eval;


### PR DESCRIPTION
Elo   | 6.07 +- 4.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.21 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 7494 W: 1833 L: 1702 D: 3959
Penta | [17, 830, 1932, 941, 27]
https://furybench.com/test/3065/