### PR TITLE
search.c: Move IIR below initial_depth assigment


### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -654,12 +654,6 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     return tt_score;
   }
 
-  // Internal Iterative Reductions
-  if ((pv_node || cutnode) && !ss->excluded_move && depth >= IIR_DEPTH &&
-      (!tt_move || tt_depth < depth - IIR_DEPTH_REDUCTION)) {
-    depth--;
-  }
-
   if (in_check) {
     ss->static_eval = NO_SCORE;
     raw_static_eval = NO_SCORE;
@@ -709,6 +703,12 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
   if (check_time(thread)) {
     stop_threads(thread, thread_count);
     return 0;
+  }
+
+  // Internal Iterative Reductions
+  if ((pv_node || cutnode) && !ss->excluded_move && depth >= IIR_DEPTH &&
+      (!tt_move || tt_depth < depth - IIR_DEPTH_REDUCTION)) {
+    depth--;
   }
 
   if ((ss - 1)->reduction >= HINDSIGH_REDUCTION_ADD && !opponent_worsening) {


### PR DESCRIPTION
Elo   | 0.36 +- 1.53 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 51734 W: 12101 L: 12048 D: 27585
Penta | [152, 6117, 13268, 6186, 144]
https://furybench.com/test/3123/