### PR TITLE
search.c: Dont treat promotions as non quiet in SEE

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -902,7 +902,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     // SEE PVS Pruning
     if (depth <= SEE_DEPTH && moves_seen > 0 &&
         !SEE(pos, move,
-             SEE_MARGIN[depth][quiet] -
+             SEE_MARGIN[depth][!get_move_capture(move)] -
                  ss->history_score / SEE_HISTORY_DIVISOR))
       continue;
 


### PR DESCRIPTION
Elo   | 2.86 +- 2.94 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 12774 W: 3001 L: 2896 D: 6877
Penta | [31, 1347, 3522, 1460, 27]
https://furybench.com/test/3127/