### PR TITLE
Source: Init and set piece to NO_PIECE in NMP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -791,7 +791,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     prefetch_hash_entry(pos_copy.hash_keys.hash_key);
 
     ss->move = 0;
-    ss->piece = 0;
+    ss->piece = NO_PIECE;
     pos_copy.checkers = 0;
     pos_copy.checker_count = 0;
     (ss + 1)->null_move = 1;
@@ -1391,7 +1391,7 @@ void *iterative_deepening(void *thread_void) {
       ss[i].eval = NO_SCORE;
       ss[i].history_score = 0;
       ss[i].move = 0;
-      ss[i].piece = 0;
+      ss[i].piece = NO_PIECE;
       ss[i].null_move = 0;
       ss[i].reduction = 0;
       ss[i].tt_pv = 0;

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -115,7 +115,7 @@ typedef struct searchinfo {
   int16_t b_non_pawn_correction_history[2][16384];
   int16_t w_non_pawn_correction_history[2][16384];
   int16_t quiet_history[2][64][64][2][2];
-  int16_t continuation_history[12][64][12][64];
+  int16_t continuation_history[13][64][12][64];
   int16_t capture_history[12][13][64][64];
   int16_t pawn_history[2048][12][64];
   uint8_t depth;


### PR DESCRIPTION
Elo   | -0.12 +- 0.97 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 119220 W: 27827 L: 27868 D: 63525
Penta | [333, 12992, 32971, 13011, 303]
https://furybench.com/test/3159/