### PR TITLE
search.c: Add protection guards to RFP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -752,6 +752,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
   // Reverse Futility Pruning
   if (!ss->tt_pv && !in_check && !ss->excluded_move && depth <= RFP_DEPTH &&
+      beta > -MATE_SCORE && ss->eval < MATE_SCORE &&
       ss->eval >= beta + RFP_BASE_MARGIN + RFP_MARGIN * depth -
                       RFP_IMPROVING * improving -
                       RFP_OPP_WORSENING * opponent_worsening) {


### PR DESCRIPTION
Elo   | 0.39 +- 1.56 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 49330 W: 11540 L: 11484 D: 26306
Penta | [134, 5788, 12783, 5808, 152]
https://furybench.com/test/3201/