### PR TITLE
net28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NETWORK_NAME = net26.nnue
+NETWORK_NAME = net28.nnue
 _THIS       := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 _ROOT       := $(_THIS)
 EVALFILE    ?= $(NETWORK_NAME)


### PR DESCRIPTION
Elo   | 26.33 +- 7.57 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 2684 W: 781 L: 578 D: 1325
Penta | [22, 239, 641, 394, 46]
https://furybench.com/test/5330/