### PR TITLE
net29

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NETWORK_NAME = net28.nnue
+NETWORK_NAME = net29.nnue
 _THIS       := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 _ROOT       := $(_THIS)
 EVALFILE    ?= $(NETWORK_NAME)


### PR DESCRIPTION
Elo   | 22.89 +- 7.08 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 3116 W: 891 L: 686 D: 1539
Penta | [31, 288, 732, 459, 48]
https://furybench.com/test/5339/