### PR TITLE
NNZ

### DIFF
--- a/Source/nnue.c
+++ b/Source/nnue.c
@@ -498,8 +498,6 @@ int nnue_evaluate(thread_t *thread, position_t *pos, accumulator_t *accumulator)
 
   simd_t *layers = &thread->neurons;
 
-  memset(layers->l2_neurons, 0, sizeof(layers->l2_neurons));
-
   const float L1_NORMALISATION =
       (float)(1 << INPUT_SHIFT) / (float)(INPUT_QUANT * INPUT_QUANT * L1_QUANT);
 
@@ -554,55 +552,77 @@ int nnue_evaluate(thread_t *thread, position_t *pos, accumulator_t *accumulator)
 
 #if defined(USE_AVX512)
   {
-    const veci_t zero_vec = zero();
-    for (int base = 0; base < NNZ_MAX; base += I32_STRIDE) {
+    const veci_t    zero_vec  = zero();
+    const __m128i   increment = _mm_set1_epi16(16);
+    __m128i         base_lo   = _mm_setzero_si128();
+    __m128i         base_hi   = _mm_set1_epi16(8);
+    for (int i = 0; i < NNZ_MAX; i += I32_STRIDE) {
       uint16_t mask = (uint16_t)~_mm512_cmpeq_epi32_mask(
-          _mm512_loadu_si512((const veci_t *)&l1Packs[base]), zero_vec);
+          _mm512_loadu_si512((const veci_t *)&l1Packs[i]), zero_vec);
 
       uint8_t lo = (uint8_t)(mask & 0xFF);
-      __m128i lo_indices = _mm_add_epi16(
-          _mm_loadu_si128((const __m128i *)NNZ_TABLE[lo]),
-          _mm_set1_epi16((short)base));
-      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count], lo_indices);
+      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count],
+          _mm_add_epi16(_mm_loadu_si128((const __m128i *)NNZ_TABLE[lo]), base_lo));
       nnz_count += __builtin_popcount(lo);
 
       uint8_t hi = (uint8_t)(mask >> 8);
-      __m128i hi_indices = _mm_add_epi16(
-          _mm_loadu_si128((const __m128i *)NNZ_TABLE[hi]),
-          _mm_set1_epi16((short)(base + 8)));
-      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count], hi_indices);
+      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count],
+          _mm_add_epi16(_mm_loadu_si128((const __m128i *)NNZ_TABLE[hi]), base_hi));
       nnz_count += __builtin_popcount(hi);
+
+      base_lo = _mm_add_epi16(base_lo, increment);
+      base_hi = _mm_add_epi16(base_hi, increment);
     }
   }
 #elif defined(USE_AVX2)
   {
-    const veci_t zero_vec = zero();
-    for (int base = 0; base < NNZ_MAX; base += I32_STRIDE) {
+    const veci_t  zero_vec  = zero();
+    const __m128i increment = _mm_set1_epi16(8);
+    __m128i       base_vec  = _mm_setzero_si128();
+    for (int i = 0; i < NNZ_MAX; i += I32_STRIDE) {
       uint8_t byte = (uint8_t)(~_mm256_movemask_ps(_mm256_castsi256_ps(
           _mm256_cmpeq_epi32(
-              _mm256_loadu_si256((const veci_t *)&l1Packs[base]),
+              _mm256_loadu_si256((const veci_t *)&l1Packs[i]),
               zero_vec))));
-      __m128i indices = _mm_add_epi16(
-          _mm_loadu_si128((const __m128i *)NNZ_TABLE[byte]),
-          _mm_set1_epi16((short)base));
-      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count], indices);
+      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count],
+          _mm_add_epi16(_mm_loadu_si128((const __m128i *)NNZ_TABLE[byte]), base_vec));
       nnz_count += __builtin_popcount(byte);
+      base_vec = _mm_add_epi16(base_vec, increment);
     }
   }
 #endif
 
-  for (int n = 0; n < nnz_count; n++) {
-    const int pack_idx = nnz_indices[n];
-    const int l1       = pack_idx * INT8_PER_INT32;
-    for (int l2 = 0; l2 < L2_SIZE; l2 += sizeof(veci_t) / sizeof(int32_t)) {
-      veci_t u8 = set_epi32(l1Packs[pack_idx]);
-      veci_t i8 =
-          *((veci_t *)&nnue
-                .l1_weights[out_bucket][l1 * L2_SIZE + INT8_PER_INT32 * l2]);
-      *((veci_t *)&layers->l2_neurons[l2]) =
-          dpbusd_epi32(*((veci_t *)&layers->l2_neurons[l2]), u8, i8);
+  const int L2_VECS = L2_SIZE / I32_STRIDE;
+  veci_t regs[L2_VECS];
+  for (int r = 0; r < L2_VECS; r++) regs[r] = zero();
+
+  int n = 0;
+  for (; n + 1 < nnz_count; n += 2) {
+    const int pack0 = nnz_indices[n];
+    const int pack1 = nnz_indices[n + 1];
+    const int l1_0  = pack0 * INT8_PER_INT32;
+    const int l1_1  = pack1 * INT8_PER_INT32;
+    const veci_t u0 = set_epi32(l1Packs[pack0]);
+    const veci_t u1 = set_epi32(l1Packs[pack1]);
+    for (int r = 0; r < L2_VECS; r++) {
+      const veci_t i0 = *((veci_t *)&nnue.l1_weights[out_bucket][l1_0 * L2_SIZE + INT8_PER_INT32 * r * I32_STRIDE]);
+      const veci_t i1 = *((veci_t *)&nnue.l1_weights[out_bucket][l1_1 * L2_SIZE + INT8_PER_INT32 * r * I32_STRIDE]);
+      regs[r] = dpbusd_epi32x2(regs[r], u0, i0, u1, i1);
     }
   }
+  if (n < nnz_count) {
+    const int pack_idx = nnz_indices[n];
+    const int l1       = pack_idx * INT8_PER_INT32;
+    const veci_t u8    = set_epi32(l1Packs[pack_idx]);
+    for (int r = 0; r < L2_VECS; r++) {
+      const veci_t i8 = *((veci_t *)&nnue.l1_weights[out_bucket][l1 * L2_SIZE + INT8_PER_INT32 * r * I32_STRIDE]);
+      regs[r] = dpbusd_epi32(regs[r], u8, i8);
+    }
+  }
+
+  // Write accumulated results back to l2_neurons once
+  for (int r = 0; r < L2_VECS; r++)
+    *((veci_t *)&layers->l2_neurons[r * I32_STRIDE]) = regs[r];
 
   memcpy(layers->l3_neurons, nnue.l2_bias[out_bucket], sizeof(layers->l3_neurons));
 
@@ -654,6 +674,8 @@ int nnue_evaluate(thread_t *thread, position_t *pos, accumulator_t *accumulator)
 
   float result = nnue.l3_bias[out_bucket] + reduce_add_ps(result_sums);
 #else
+
+  memset(layers->l2_neurons, 0, sizeof(layers->l2_neurons));
 
   for (int l1 = 0; l1 < L1_SIZE / 2; l1++) {
     int16_t stmClipped1 = clamp((int)(stmAcc[l1]), 0, INPUT_QUANT);

--- a/Source/nnue.c
+++ b/Source/nnue.c
@@ -437,7 +437,6 @@ int nnue_eval_pos(position_t *pos, accumulator_t *accumulator) {
   int l2Neurons[L2_SIZE] = {0};
 
   for (int l1 = 0; l1 < L1_SIZE; l1++) {
-    if (!l1Neurons[l1]) continue;
     for (int l2 = 0; l2 < L2_SIZE; l2++) {
       l2Neurons[l2] +=
           l1Neurons[l1] * nnue.l1_weights[out_bucket][l1 * L2_SIZE + l2];
@@ -640,7 +639,6 @@ int nnue_evaluate(thread_t *thread, position_t *pos, accumulator_t *accumulator)
   }
 
   for (int l1 = 0; l1 < L1_SIZE; l1++) {
-    if (!layers->l1_neurons[l1]) continue;
     for (int l2 = 0; l2 < L2_SIZE; l2++) {
       layers->l2_neurons[l2] +=
           layers->l1_neurons[l1] * nnue.l1_weights[out_bucket][l1 * L2_SIZE + l2];

--- a/Source/nnue.c
+++ b/Source/nnue.c
@@ -31,6 +31,20 @@ struct raw_net net;
 
 const int INT8_PER_INT32 = sizeof(int) / sizeof(int8_t);
 
+#if defined(USE_SIMD) && (defined(USE_AVX2) || defined(USE_AVX512))
+static uint16_t NNZ_TABLE[256][8];
+
+static void init_nnz_table(void) {
+  for (int i = 0; i < 256; i++) {
+    int count = 0;
+    for (int j = 0; j < 8; j++) {
+      if (i & (1 << j))
+        NNZ_TABLE[i][count++] = (uint16_t)j;
+    }
+  }
+}
+#endif
+
 uint8_t buckets[64] = {7,7,7,7,7,7,7,7,
                        7,7,7,7,7,7,7,7,
                       7,7,7,7,7,7,7,7,
@@ -232,6 +246,9 @@ void nnue_init(const char *nnue_file_name) {
       exit(1);
     }
   }
+#if defined(USE_SIMD) && (defined(USE_AVX2) || defined(USE_AVX512))
+  init_nnz_table();
+#endif
   transpose();
 }
 
@@ -532,32 +549,44 @@ int nnue_evaluate(thread_t *thread, position_t *pos, accumulator_t *accumulator)
 
   const int NNZ_MAX    = L1_SIZE / INT8_PER_INT32;
   const int I32_STRIDE = sizeof(veci_t) / sizeof(int32_t);
-  uint16_t nnz_indices[NNZ_MAX];
+  uint16_t nnz_indices[NNZ_MAX + 8];
   int nnz_count = 0;
 
 #if defined(USE_AVX512)
   {
     const veci_t zero_vec = zero();
     for (int base = 0; base < NNZ_MAX; base += I32_STRIDE) {
-      __mmask16 nz = ~_mm512_cmpeq_epi32_mask(
+      uint16_t mask = (uint16_t)~_mm512_cmpeq_epi32_mask(
           _mm512_loadu_si512((const veci_t *)&l1Packs[base]), zero_vec);
-      while (nz) {
-        nnz_indices[nnz_count++] = (uint16_t)(base + __builtin_ctz(nz));
-        nz &= nz - 1;
-      }
+
+      uint8_t lo = (uint8_t)(mask & 0xFF);
+      __m128i lo_indices = _mm_add_epi16(
+          _mm_loadu_si128((const __m128i *)NNZ_TABLE[lo]),
+          _mm_set1_epi16((short)base));
+      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count], lo_indices);
+      nnz_count += __builtin_popcount(lo);
+
+      uint8_t hi = (uint8_t)(mask >> 8);
+      __m128i hi_indices = _mm_add_epi16(
+          _mm_loadu_si128((const __m128i *)NNZ_TABLE[hi]),
+          _mm_set1_epi16((short)(base + 8)));
+      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count], hi_indices);
+      nnz_count += __builtin_popcount(hi);
     }
   }
 #elif defined(USE_AVX2)
   {
     const veci_t zero_vec = zero();
     for (int base = 0; base < NNZ_MAX; base += I32_STRIDE) {
-      veci_t chunk = _mm256_loadu_si256((const veci_t *)&l1Packs[base]);
-      int nz       = ~_mm256_movemask_ps(_mm256_castsi256_ps(
-                         _mm256_cmpeq_epi32(chunk, zero_vec))) & 0xFF;
-      while (nz) {
-        nnz_indices[nnz_count++] = (uint16_t)(base + __builtin_ctz(nz));
-        nz &= nz - 1;
-      }
+      uint8_t byte = (uint8_t)(~_mm256_movemask_ps(_mm256_castsi256_ps(
+          _mm256_cmpeq_epi32(
+              _mm256_loadu_si256((const veci_t *)&l1Packs[base]),
+              zero_vec))));
+      __m128i indices = _mm_add_epi16(
+          _mm_loadu_si128((const __m128i *)NNZ_TABLE[byte]),
+          _mm_set1_epi16((short)base));
+      _mm_storeu_si128((__m128i *)&nnz_indices[nnz_count], indices);
+      nnz_count += __builtin_popcount(byte);
     }
   }
 #endif

--- a/Source/nnue.c
+++ b/Source/nnue.c
@@ -437,6 +437,7 @@ int nnue_eval_pos(position_t *pos, accumulator_t *accumulator) {
   int l2Neurons[L2_SIZE] = {0};
 
   for (int l1 = 0; l1 < L1_SIZE; l1++) {
+    if (!l1Neurons[l1]) continue;
     for (int l2 = 0; l2 < L2_SIZE; l2++) {
       l2Neurons[l2] +=
           l1Neurons[l1] * nnue.l1_weights[out_bucket][l1 * L2_SIZE + l2];
@@ -530,9 +531,43 @@ int nnue_evaluate(thread_t *thread, position_t *pos, accumulator_t *accumulator)
 
   int *l1Packs = (int *)layers->l1_neurons;
 
-  for (int l1 = 0; l1 < L1_SIZE; l1 += INT8_PER_INT32) {
+  const int NNZ_MAX    = L1_SIZE / INT8_PER_INT32;
+  const int I32_STRIDE = sizeof(veci_t) / sizeof(int32_t);
+  uint16_t nnz_indices[NNZ_MAX];
+  int nnz_count = 0;
+
+#if defined(USE_AVX512)
+  {
+    const veci_t zero_vec = zero();
+    for (int base = 0; base < NNZ_MAX; base += I32_STRIDE) {
+      __mmask16 nz = ~_mm512_cmpeq_epi32_mask(
+          _mm512_loadu_si512((const veci_t *)&l1Packs[base]), zero_vec);
+      while (nz) {
+        nnz_indices[nnz_count++] = (uint16_t)(base + __builtin_ctz(nz));
+        nz &= nz - 1;
+      }
+    }
+  }
+#elif defined(USE_AVX2)
+  {
+    const veci_t zero_vec = zero();
+    for (int base = 0; base < NNZ_MAX; base += I32_STRIDE) {
+      veci_t chunk = _mm256_loadu_si256((const veci_t *)&l1Packs[base]);
+      int nz       = ~_mm256_movemask_ps(_mm256_castsi256_ps(
+                         _mm256_cmpeq_epi32(chunk, zero_vec))) & 0xFF;
+      while (nz) {
+        nnz_indices[nnz_count++] = (uint16_t)(base + __builtin_ctz(nz));
+        nz &= nz - 1;
+      }
+    }
+  }
+#endif
+
+  for (int n = 0; n < nnz_count; n++) {
+    const int pack_idx = nnz_indices[n];
+    const int l1       = pack_idx * INT8_PER_INT32;
     for (int l2 = 0; l2 < L2_SIZE; l2 += sizeof(veci_t) / sizeof(int32_t)) {
-      veci_t u8 = set_epi32(l1Packs[l1 / INT8_PER_INT32]);
+      veci_t u8 = set_epi32(l1Packs[pack_idx]);
       veci_t i8 =
           *((veci_t *)&nnue
                 .l1_weights[out_bucket][l1 * L2_SIZE + INT8_PER_INT32 * l2]);
@@ -605,6 +640,7 @@ int nnue_evaluate(thread_t *thread, position_t *pos, accumulator_t *accumulator)
   }
 
   for (int l1 = 0; l1 < L1_SIZE; l1++) {
+    if (!layers->l1_neurons[l1]) continue;
     for (int l2 = 0; l2 < L2_SIZE; l2++) {
       layers->l2_neurons[l2] +=
           layers->l1_neurons[l1] * nnue.l1_weights[out_bucket][l1 * L2_SIZE + l2];

--- a/Source/simd.h
+++ b/Source/simd.h
@@ -48,6 +48,13 @@ static inline veci_t dpbusd_epi32(veci_t sum, veci_t u, veci_t i) {
   return _mm512_add_epi32(sum32, sum);
 }
 #endif
+
+static inline veci_t dpbusd_epi32x2(veci_t sum, veci_t u0, veci_t i0, veci_t u1, veci_t i1) {
+  veci_t p0    = _mm512_maddubs_epi16(u0, i0);
+  veci_t p1    = _mm512_maddubs_epi16(u1, i1);
+  veci_t sum32 = _mm512_madd_epi16(_mm512_add_epi16(p0, p1), _mm512_set1_epi16(1));
+  return _mm512_add_epi32(sum32, sum);
+}
 static inline veci_t add_epi32(veci_t v1, veci_t v2) {
   return _mm512_add_epi32(v1, v2);
 }
@@ -108,6 +115,13 @@ static inline void vec_store_i(veci_t *scalar, veci_t integer) {
 static inline veci_t dpbusd_epi32(veci_t sum, veci_t u, veci_t i) {
   veci_t sum32 =
       _mm256_madd_epi16(_mm256_maddubs_epi16(u, i), _mm256_set1_epi16(1));
+  return _mm256_add_epi32(sum, sum32);
+}
+
+static inline veci_t dpbusd_epi32x2(veci_t sum, veci_t u0, veci_t i0, veci_t u1, veci_t i1) {
+  veci_t p0    = _mm256_maddubs_epi16(u0, i0);
+  veci_t p1    = _mm256_maddubs_epi16(u1, i1);
+  veci_t sum32 = _mm256_madd_epi16(_mm256_add_epi16(p0, p1), _mm256_set1_epi16(1));
   return _mm256_add_epi32(sum, sum32);
 }
 static inline veci_t add_epi32(veci_t v1, veci_t v2) {


### PR DESCRIPTION
Elo   | 2.67 +- 1.97 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 33614 W: 8612 L: 8354 D: 16648
Penta | [247, 3552, 8988, 3736, 284]
https://furybench.com/test/5557/

Elo   | 3.76 +- 2.59 (95%)
SPRT  | 4.0+0.04s Threads=1 Hash=16MB
LLR   | 2.71 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19494 W: 5002 L: 4791 D: 9701
Penta | [114, 2142, 5067, 2267, 157]
https://furybench.com/test/5559/