### PR TITLE
Thread pos refactor

### DIFF
--- a/Source/datagen.c
+++ b/Source/datagen.c
@@ -64,7 +64,7 @@ uint8_t play_rand_moves(position_t *pos, thread_t *thread, uint8_t rand_moves) {
         strcpy(input, "position fen ");
         strcat(input, fen);
         parse_position(pos, thread, input);
-        init_accumulator(pos, &thread->accumulator[pos->ply]);
+        init_accumulator(pos, &thread->accumulator[thread->ply]);
         init_finny_tables(thread, pos);
         time_control(pos, thread, "go depth 10");
         search_position(pos, thread);
@@ -98,7 +98,7 @@ void genfens(position_t *pos, thread_t *thread, uint64_t seed,
             char input[512];
             sprintf(input, "position fen %s", fen);
             parse_position(pos, thread, input);
-            init_accumulator(pos, &thread->accumulator[pos->ply]);
+            init_accumulator(pos, &thread->accumulator[thread->ply]);
             init_finny_tables(thread, pos);
         }
         position_t pos_copy = *pos;

--- a/Source/history.c
+++ b/Source/history.c
@@ -166,8 +166,8 @@ uint8_t static_eval_within_bounds(int16_t static_eval, int16_t score,
          !(failed_low && static_eval < score);
 }
 
-int16_t adjust_static_eval(thread_t *thread, position_t *pos,
-                           int16_t static_eval) {
+int16_t adjust_static_eval(thread_t *thread, int16_t static_eval) {
+  position_t *pos = &thread->positions[thread->ply];
   const float fifty_move_scaler =
       (float)((FIFTY_MOVE_SCALING - (float)pos->fifty) / 200);
   static_eval = static_eval * fifty_move_scaler;
@@ -190,7 +190,8 @@ int16_t adjust_static_eval(thread_t *thread, position_t *pos,
   return clamp(adjusted_score, -MATE_SCORE + 1, MATE_SCORE - 1);
 }
 
-int16_t correction_value(thread_t *thread, position_t *pos) {
+int16_t correction_value(thread_t *thread) {
+  position_t *pos = &thread->positions[thread->ply];
   const int pawn_correction =
       thread->correction_history[pos->side][pos->hash_keys.pawn_key & 16383] *
       PAWN_CORR_HISTORY_MULTIPLIER;
@@ -209,34 +210,35 @@ int16_t correction_value(thread_t *thread, position_t *pos) {
   return correction / 1024;
 }
 
-void update_corrhist(thread_t *thread, position_t *pos, int16_t static_eval,
+void update_corrhist(thread_t *thread, int16_t static_eval,
                      int16_t score, uint8_t depth) {
+  position_t *pos = &thread->positions[thread->ply];
   int16_t bonus = calculate_corrhist_bonus(static_eval, score, depth);
+
   thread->correction_history[pos->side][pos->hash_keys.pawn_key & 16383] +=
       scale_corrhist_bonus(
-          thread
-              ->correction_history[pos->side][pos->hash_keys.pawn_key & 16383],
+          thread->correction_history[pos->side]
+                                    [pos->hash_keys.pawn_key & 16383],
           bonus);
 
   thread->w_non_pawn_correction_history
-      [thread->pos.side][thread->pos.hash_keys.non_pawn_key[white] & 16383] +=
+      [pos->side][pos->hash_keys.non_pawn_key[white] & 16383] +=
       scale_corrhist_bonus(
           thread->w_non_pawn_correction_history
-              [thread->pos.side]
-              [thread->pos.hash_keys.non_pawn_key[white] & 16383],
+              [pos->side][pos->hash_keys.non_pawn_key[white] & 16383],
           bonus);
 
   thread->b_non_pawn_correction_history
-      [thread->pos.side][thread->pos.hash_keys.non_pawn_key[black] & 16383] +=
+      [pos->side][pos->hash_keys.non_pawn_key[black] & 16383] +=
       scale_corrhist_bonus(
           thread->b_non_pawn_correction_history
-              [thread->pos.side]
-              [thread->pos.hash_keys.non_pawn_key[black] & 16383],
+              [pos->side][pos->hash_keys.non_pawn_key[black] & 16383],
           bonus);
 }
 
-void update_quiet_history(thread_t *thread, position_t *pos, searchstack_t *ss,
+void update_quiet_history(thread_t *thread, searchstack_t *ss,
                           int move, int bonus) {
+  position_t *pos = &thread->positions[thread->ply];
   int target = get_move_target(move);
   int source = get_move_source(move);
   thread->quiet_history[pos->side][source][target][is_square_threatened(
@@ -247,9 +249,9 @@ void update_quiet_history(thread_t *thread, position_t *pos, searchstack_t *ss,
           abs(bonus) / HISTORY_MAX;
 }
 
-static inline void update_capture_history(thread_t *thread, position_t *pos,
-                                          searchstack_t *ss, int move,
-                                          int bonus) {
+static inline void update_capture_history(thread_t *thread, searchstack_t *ss,
+                                          int move, int bonus) {
+  position_t *pos = &thread->positions[thread->ply];
   int from = get_move_source(move);
   int target = get_move_target(move);
   int prev_target_piece = get_move_enpassant(move) == 0
@@ -267,25 +269,11 @@ static inline void update_capture_history(thread_t *thread, position_t *pos,
           abs(bonus) / HISTORY_MAX;
 }
 
-/*static inline void update_continuation_history(thread_t *thread,
-                                               position_t *pos,
-                                               searchstack_t *ss, int move,
-                                               int bonus) {
-  int prev_piece = ss->piece;
-  int prev_target = get_move_target(ss->move);
-  int piece = pos->mailbox[get_move_source(move)];
-  int target = get_move_target(move);
-  thread->continuation_history[prev_piece][prev_target][piece][target] +=
-      bonus -
-      thread->continuation_history[prev_piece][prev_target][piece][target] *
-          abs(bonus) / HISTORY_MAX;
-}*/
-
-int16_t get_conthist_score(thread_t *thread, position_t *pos, searchstack_t *ss,
+int16_t get_conthist_score(thread_t *thread, searchstack_t *ss,
                            int move, uint8_t ply) {
-  if (pos->ply >= ply && (ss - ply)->piece != NO_PIECE) {
+  if (thread->ply >= ply && (ss - ply)->piece != NO_PIECE) {
     return thread->continuation_history[(ss - ply)->piece][get_move_target(
-        (ss - ply)->move)][pos->mailbox[get_move_source(move)]]
+        (ss - ply)->move)][thread->positions[thread->ply].mailbox[get_move_source(move)]]
                                        [get_move_target(move)];
   } else {
     return 0;
@@ -293,16 +281,16 @@ int16_t get_conthist_score(thread_t *thread, position_t *pos, searchstack_t *ss,
 }
 
 static inline void update_continuation_histories(thread_t *thread,
-                                                 position_t *pos,
                                                  searchstack_t *ss, int move,
                                                  int bonus) {
+  position_t *pos = &thread->positions[thread->ply];
   uint8_t count = sizeof(cont_hist_updates) / sizeof(uint8_t);
-  int64_t total_score = get_conthist_score(thread, pos, ss, move, 1) +
-                        get_conthist_score(thread, pos, ss, move, 2) +
-                        get_conthist_score(thread, pos, ss, move, 4);
+  int64_t total_score = get_conthist_score(thread, ss, move, 1) +
+                        get_conthist_score(thread, ss, move, 2) +
+                        get_conthist_score(thread, ss, move, 4);
   for (uint8_t i = 0; i < count; ++i) {
     int prev_piece = (ss - cont_hist_updates[i])->piece;
-    if (pos->ply >= cont_hist_updates[i] && prev_piece != NO_PIECE) {
+    if (thread->ply >= cont_hist_updates[i] && prev_piece != NO_PIECE) {
       int prev_target = get_move_target((ss - cont_hist_updates[i])->move);
       int piece = pos->mailbox[get_move_source(move)];
       int target = get_move_target(move);
@@ -312,8 +300,8 @@ static inline void update_continuation_histories(thread_t *thread,
   }
 }
 
-static inline void update_pawn_history(thread_t *thread, position_t *pos,
-                                       int move, int bonus) {
+static inline void update_pawn_history(thread_t *thread, int move, int bonus) {
+  position_t *pos = &thread->positions[thread->ply];
   int target = get_move_target(move);
   int source = get_move_source(move);
   thread->pawn_history[pos->hash_keys.pawn_key % 2048][pos->mailbox[source]]
@@ -323,9 +311,9 @@ static inline void update_pawn_history(thread_t *thread, position_t *pos,
                   abs(bonus) / HISTORY_MAX;
 }
 
-void update_capture_history_moves(thread_t *thread, position_t *pos,
-                                  searchstack_t *ss, moves *capture_moves,
-                                  int best_move, uint8_t depth) {
+void update_capture_history_moves(thread_t *thread, searchstack_t *ss,
+                                  moves *capture_moves, int best_move,
+                                  uint8_t depth) {
   int capt_bonus =
       MIN(CAPTURE_HISTORY_BASE_BONUS + CAPTURE_HISTORY_FACTOR_BONUS * depth,
           CAPTURE_HISTORY_BONUS_MAX);
@@ -334,17 +322,16 @@ void update_capture_history_moves(thread_t *thread, position_t *pos,
            CAPTURE_HISTORY_MALUS_MAX);
   for (uint32_t i = 0; i < capture_moves->count; ++i) {
     if (capture_moves->entry[i].move == best_move) {
-      update_capture_history(thread, pos, ss, best_move, capt_bonus);
+      update_capture_history(thread, ss, best_move, capt_bonus);
     } else {
-      update_capture_history(thread, pos, ss, capture_moves->entry[i].move,
+      update_capture_history(thread, ss, capture_moves->entry[i].move,
                              capt_malus);
     }
   }
 }
 
-void update_quiet_histories(thread_t *thread, position_t *pos,
-                            searchstack_t *ss, moves *quiet_moves,
-                            int best_move, uint8_t depth) {
+void update_quiet_histories(thread_t *thread, searchstack_t *ss,
+                            moves *quiet_moves, int best_move, uint8_t depth) {
   int cont_bonus =
       MIN(CONT_HISTORY_BASE_BONUS + CONT_HISTORY_FACTOR_BONUS * depth,
           CONT_HISTORY_BONUS_MAX);
@@ -368,13 +355,13 @@ void update_quiet_histories(thread_t *thread, position_t *pos,
   for (uint32_t i = 0; i < quiet_moves->count; ++i) {
     uint16_t move = quiet_moves->entry[i].move;
     if (move == best_move) {
-      update_continuation_histories(thread, pos, ss, best_move, cont_bonus);
-      update_pawn_history(thread, pos, best_move, pawn_bonus);
-      update_quiet_history(thread, pos, ss, best_move, quiet_bonus);
+      update_continuation_histories(thread, ss, best_move, cont_bonus);
+      update_pawn_history(thread, best_move, pawn_bonus);
+      update_quiet_history(thread, ss, best_move, quiet_bonus);
     } else {
-      update_continuation_histories(thread, pos, ss, move, cont_malus);
-      update_pawn_history(thread, pos, move, pawn_malus);
-      update_quiet_history(thread, pos, ss, move, quiet_malus);
+      update_continuation_histories(thread, ss, move, cont_malus);
+      update_pawn_history(thread, move, pawn_malus);
+      update_quiet_history(thread, ss, move, quiet_malus);
     }
   }
 }

--- a/Source/history.h
+++ b/Source/history.h
@@ -7,21 +7,18 @@ uint64_t generate_pawn_key(position_t *pos);
 uint64_t generate_white_non_pawn_key(position_t *pos);
 uint64_t generate_black_non_pawn_key(position_t *pos);
 
-void update_corrhist(thread_t *thread, position_t *pos, int16_t static_eval,
+void update_corrhist(thread_t *thread, int16_t static_eval,
                      int16_t score, uint8_t depth);
-int16_t adjust_static_eval(thread_t *thread, position_t *pos,
-                           int16_t static_eval);
-int16_t correction_value(thread_t *thread, position_t *pos);
-void update_capture_history_moves(thread_t *thread, position_t *pos,
-                                  searchstack_t *ss, moves *capture_moves,
-                                  int best_move, uint8_t depth);
-int16_t get_conthist_score(thread_t *thread, position_t *pos, searchstack_t *ss,
+int16_t adjust_static_eval(thread_t *thread, int16_t static_eval);
+int16_t correction_value(thread_t *thread);
+void update_capture_history_moves(thread_t *thread, searchstack_t *ss,
+                                  moves *capture_moves, int best_move,
+                                  uint8_t depth);
+int16_t get_conthist_score(thread_t *thread, searchstack_t *ss,
                            int move, uint8_t ply);
-void update_quiet_histories(thread_t *thread, position_t *pos,
-                            searchstack_t *ss, moves *quiet_moves,
-                            int best_move, uint8_t depth);
-
-void update_quiet_history(thread_t *thread, position_t *pos, searchstack_t *ss,
+void update_quiet_histories(thread_t *thread, searchstack_t *ss,
+                            moves *quiet_moves, int best_move, uint8_t depth);
+void update_quiet_history(thread_t *thread, searchstack_t *ss,
                           int move, int bonus);
 
 #endif

--- a/Source/nnue.c
+++ b/Source/nnue.c
@@ -489,7 +489,7 @@ int nnue_eval_pos(position_t *pos, accumulator_t *accumulator) {
 
 int nnue_evaluate(thread_t *thread, position_t *pos,
                   accumulator_t *accumulator) {
-  apply_accumulator(thread, pos->ply);
+  apply_accumulator(thread, thread->ply);
   const uint8_t out_bucket = calculate_output_bucket(pos);
   const int16_t *stmAcc = accumulator->accumulator[pos->side];
   const int16_t *oppAcc = accumulator->accumulator[1 - pos->side];
@@ -1002,7 +1002,7 @@ void null_move_copy_accumulator(thread_t *thread, int src_ply, int dst_ply) {
 
 void update_nnue(position_t *pos, thread_t *thread, uint8_t mailbox_copy[64],
                  uint16_t move) {
-  lazy_acc_state_t *state = &thread->lazy[pos->ply];
+  lazy_acc_state_t *state = &thread->lazy[thread->ply];
   const int from = get_move_source(move);
   const int to   = get_move_target(move);
 

--- a/Source/search.c
+++ b/Source/search.c
@@ -208,7 +208,8 @@ uint8_t check_time(thread_t *thread) {
 }
 
 // position repetition detection
-static inline uint8_t is_repetition(position_t *pos, thread_t *thread) {
+static inline uint8_t is_repetition(thread_t *thread) {
+  position_t *pos = &thread->positions[thread->ply];
   // loop over repetition indices range
   for (uint32_t index = 0; index < thread->repetition_index; index++)
     // if we found the hash key same with a current
@@ -265,10 +266,10 @@ static inline move_t pick_next_best_move(moves *move_list, uint16_t *index) {
 }
 
 // Scores noisy moves and splits them into good/bad lists based on SEE
-static inline void score_noisy(position_t *pos, thread_t *thread,
-                                searchstack_t *ss, moves *noisy_list,
-                                moves *good_noisy, moves *bad_noisy,
-                                uint16_t tt_move) {
+static inline void score_noisy(thread_t *thread, searchstack_t *ss,
+                                moves *noisy_list, moves *good_noisy,
+                                moves *bad_noisy, uint16_t tt_move) {
+  position_t *pos = &thread->positions[thread->ply];
   for (uint32_t i = 0; i < noisy_list->count; i++) {
     move_t entry = noisy_list->entry[i];
     uint16_t move = entry.move;
@@ -303,9 +304,9 @@ static inline void score_noisy(position_t *pos, thread_t *thread,
 }
 
 // Scores quiet moves in place
-static inline void score_quiet(position_t *pos, thread_t *thread,
-                                searchstack_t *ss, moves *quiet_list,
-                                uint16_t tt_move) {
+static inline void score_quiet(thread_t *thread, searchstack_t *ss,
+                                moves *quiet_list, uint16_t tt_move) {
+  position_t *pos = &thread->positions[thread->ply];
   for (uint32_t i = 0; i < quiet_list->count; i++) {
     move_t *entry = &quiet_list->entry[i];
     uint16_t move = entry->move;
@@ -324,9 +325,9 @@ static inline void score_quiet(position_t *pos, thread_t *thread,
         thread->quiet_history[pos->side][source][target]
                              [source_threatened][target_threatened] *
             MO_QUIET_HIST_MULT +
-        get_conthist_score(thread, pos, ss, move, 1) * MO_CONT1_HIST_MULT +
-        get_conthist_score(thread, pos, ss, move, 2) * MO_CONT2_HIST_MULT +
-        get_conthist_score(thread, pos, ss, move, 4) * MO_CONT4_HIST_MULT +
+        get_conthist_score(thread, ss, move, 1) * MO_CONT1_HIST_MULT +
+        get_conthist_score(thread, ss, move, 2) * MO_CONT2_HIST_MULT +
+        get_conthist_score(thread, ss, move, 4) * MO_CONT4_HIST_MULT +
         thread->pawn_history[pos->hash_keys.pawn_key % 2048]
                             [pos->mailbox[source]][target] *
             MO_PAWN_HIST_MULT;
@@ -355,14 +356,13 @@ typedef struct {
   uint16_t        tt_move;
   uint8_t         generate_all;
   uint8_t         skip_quiets;
-  position_t     *pos;
   thread_t       *thread;
   searchstack_t  *ss;
 } picker_t;
 
-static inline void init_picker(picker_t *picker, position_t *pos,
-                                thread_t *thread, searchstack_t *ss,
-                                uint16_t tt_move, uint8_t generate_all) {
+static inline void init_picker(picker_t *picker, thread_t *thread,
+                                searchstack_t *ss, uint16_t tt_move,
+                                uint8_t generate_all) {
   picker->stage             = STAGE_TABLE;
   picker->good_noisy.count  = 0;
   picker->bad_noisy.count   = 0;
@@ -373,27 +373,28 @@ static inline void init_picker(picker_t *picker, position_t *pos,
   picker->tt_move           = tt_move;
   picker->generate_all      = generate_all;
   picker->skip_quiets       = 0;
-  picker->pos               = pos;
   picker->thread            = thread;
   picker->ss                = ss;
 }
 
 static inline uint16_t select_next(picker_t *picker) {
+  position_t *pos = &picker->thread->positions[picker->thread->ply];
+
   switch (picker->stage) {
 
   case STAGE_TABLE:
     picker->stage = STAGE_GENERATE_NOISY;
     if (picker->tt_move != 0
         && (picker->generate_all || get_move_capture(picker->tt_move) || is_move_promotion(picker->tt_move))
-        && is_pseudo_legal(picker->pos, picker->tt_move)
-        && is_legal(picker->pos, picker->tt_move))
+        && is_pseudo_legal(pos, picker->tt_move)
+        && is_legal(pos, picker->tt_move))
       return picker->tt_move;
     /* fallthrough */
 
   case STAGE_GENERATE_NOISY: {
     moves tmp;
-    generate_noisy(picker->pos, &tmp, 0);
-    score_noisy(picker->pos, picker->thread, picker->ss, &tmp,
+    generate_noisy(pos, &tmp, 0);
+    score_noisy(picker->thread, picker->ss, &tmp,
                 &picker->good_noisy, &picker->bad_noisy, picker->tt_move);
     picker->stage = STAGE_GOOD_NOISY;
     /* fallthrough */
@@ -413,8 +414,8 @@ static inline uint16_t select_next(picker_t *picker) {
     if (picker->skip_quiets) {
       picker->stage = STAGE_BAD_NOISY;
     } else {
-      generate_quiets(picker->pos, &picker->quiets, 0);
-      score_quiet(picker->pos, picker->thread, picker->ss,
+      generate_quiets(pos, &picker->quiets, 0);
+      score_quiet(picker->thread, picker->ss,
                   &picker->quiets, picker->tt_move);
       picker->stage = STAGE_QUIET;
     }
@@ -448,9 +449,13 @@ static inline uint16_t select_next(picker_t *picker) {
 }
 
 // quiescence search
-static inline int16_t quiescence(position_t *pos, thread_t *thread,
-                                 searchstack_t *ss, int16_t alpha, int16_t beta,
+static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
+                                 int16_t alpha, int16_t beta,
                                  uint8_t pv_node) {
+  const uint8_t ply = thread->ply;
+  // Derive current position from the thread's position stack.
+  position_t *pos = &thread->positions[ply];
+
   // Check on time
   if (check_time(thread)) {
     stop_threads(thread, thread_count);
@@ -459,13 +464,13 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
 
   // we are too deep, hence there's an overflow of arrays relying on max ply
   // constant
-  if (pos->ply > MAX_PLY - 4) {
+  if (ply > MAX_PLY - 4) {
     // evaluate position
-    return evaluate(thread, pos, &thread->accumulator[pos->ply]);
+    return evaluate(thread, pos, &thread->accumulator[ply]);
   }
 
-  if (pos->ply > thread->seldepth) {
-    thread->seldepth = pos->ply;
+  if (ply > thread->seldepth) {
+    thread->seldepth = ply;
   }
 
   uint16_t best_move = 0;
@@ -503,7 +508,7 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
     if (tt_hit && tt_static_eval != NO_SCORE) {
       raw_static_eval = tt_static_eval;
       ss->static_eval = best_score =
-          adjust_static_eval(thread, pos, raw_static_eval);
+          adjust_static_eval(thread, raw_static_eval);
 
       if (tt_score != NO_SCORE && ((tt_flag == HASH_FLAG_EXACT) ||
                                    ((tt_flag == HASH_FLAG_UPPER_BOUND) &&
@@ -513,9 +518,9 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
         best_score = tt_score;
       }
     } else {
-      raw_static_eval = evaluate(thread, pos, &thread->accumulator[pos->ply]);
+      raw_static_eval = evaluate(thread, pos, &thread->accumulator[ply]);
       ss->static_eval = best_score =
-          adjust_static_eval(thread, pos, raw_static_eval);
+          adjust_static_eval(thread, raw_static_eval);
     }
 
     // fail-hard beta cutoff
@@ -538,7 +543,7 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
   }
 
   picker_t picker;
-  init_picker(&picker, pos, thread, ss, tt_move, in_check);
+  init_picker(&picker, thread, ss, tt_move, in_check);
 
   moves capture_list[1];
   capture_list->count = 0;
@@ -577,23 +582,22 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
       }
     }
 
-    // preserve board state
-    position_t pos_copy = *pos;
-
-    // increment ply
-    pos_copy.ply++;
+    // Copy current ply's position to the next ply slot and advance.
+    thread->positions[++thread->ply] = *pos;
+    position_t *next_pos = &thread->positions[thread->ply];
+    next_pos->ply = thread->ply;
 
     // increment repetition index & store hash key
     thread->repetition_index++;
     thread->repetition_table[thread->repetition_index] =
-        pos_copy.hash_keys.hash_key;
+        next_pos->hash_keys.hash_key;
 
-    // make sure to make only legal moves
-    make_move(&pos_copy, move);
+    // make move on the new ply's position
+    make_move(next_pos, move);
 
-    calculate_threats(&pos_copy, ss + 1);
+    calculate_threats(next_pos, ss + 1);
 
-    update_nnue(&pos_copy, thread, pos->mailbox, move);
+    update_nnue(next_pos, thread, pos->mailbox, move);
 
     ss->move = move;
     ss->piece = pos->mailbox[get_move_source(move)];
@@ -604,19 +608,14 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
       add_move(capture_list, move);
     }
 
-    prefetch_hash_entry(pos_copy.hash_keys.hash_key);
+    prefetch_hash_entry(next_pos->hash_keys.hash_key);
 
     // score current move
-    score = -quiescence(&pos_copy, thread, ss + 1, -beta, -alpha, pv_node);
+    score = -quiescence(thread, ss + 1, -beta, -alpha, pv_node);
 
-    // decrement ply
-    pos_copy.ply--;
-
-    // decrement repetition index
+    // restore ply (position is unchanged at thread->ply, no board restore needed)
+    thread->ply--;
     thread->repetition_index--;
-
-    // take move back
-    //*pos = pos_copy;
 
     // return 0 if time is up
     if (thread->stopped == 1) {
@@ -631,8 +630,7 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
         best_move = move;
         // fail-hard beta cutoff
         if (alpha >= beta) {
-          update_capture_history_moves(thread, pos, ss, capture_list, best_move,
-                                       1);
+          update_capture_history_moves(thread, ss, capture_list, best_move, 1);
           break;
         }
       }
@@ -644,7 +642,7 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
     // king is in check
     if (in_check)
       // return mating score (assuming closest distance to mating position)
-      return -MATE_VALUE + pos->ply;
+      return -MATE_VALUE + ply;
   }
 
   uint8_t hash_flag = HASH_FLAG_NONE;
@@ -661,18 +659,22 @@ static inline int16_t quiescence(position_t *pos, thread_t *thread,
 }
 
 // negamax alpha beta search
-static inline int16_t negamax(position_t *pos, thread_t *thread,
-                              searchstack_t *ss, int16_t alpha, int16_t beta,
-                              int depth, uint8_t cutnode, uint8_t pv_node) {
+static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
+                              int16_t alpha, int16_t beta, int depth,
+                              uint8_t cutnode, uint8_t pv_node) {
+  const uint8_t ply = thread->ply;
+  // Derive current position from the thread's position stack.
+  position_t *pos = &thread->positions[ply];
+
   // we are too deep, hence there's an overflow of arrays relying on max ply
   // constant
-  if (pos->ply > MAX_PLY - 4) {
+  if (ply > MAX_PLY - 4) {
     // evaluate position
-    return evaluate(thread, pos, &thread->accumulator[pos->ply]);
+    return evaluate(thread, pos, &thread->accumulator[ply]);
   }
 
   // init PV length
-  thread->pv.pv_length[pos->ply] = pos->ply;
+  thread->pv.pv_length[ply] = ply;
 
   // variable to store current move's score (from the static evaluation
   // perspective)
@@ -687,26 +689,26 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
   uint8_t tt_flag = HASH_FLAG_EXACT;
   ss->tt_pv = ss->excluded_move ? ss->tt_pv : pv_node;
 
-  uint8_t root_node = pos->ply == 0;
+  uint8_t root_node = ply == 0;
   uint8_t all_node = !(pv_node || cutnode);
 
   // Limit depth to MAX_PLY - 1 in case extensions make it too big
   depth = clamp(depth, 0, MAX_PLY - 1);
 
-  if (depth == 0 && pos->ply > thread->seldepth) {
-    thread->seldepth = pos->ply;
+  if (depth == 0 && ply > thread->seldepth) {
+    thread->seldepth = ply;
   }
 
   if (!root_node) {
     // if position repetition occurs
-    if (is_repetition(pos, thread) || pos->fifty >= 100) {
+    if (is_repetition(thread) || pos->fifty >= 100) {
       // return draw score
       return 1 - (thread->nodes & 2);
     }
 
     // Mate distance pruning
-    alpha = MAX(alpha, -MATE_VALUE + (int)pos->ply);
-    beta = MIN(beta, MATE_VALUE - (int)pos->ply - 1);
+    alpha = MAX(alpha, -MATE_VALUE + (int)ply);
+    beta = MIN(beta, MATE_VALUE - (int)ply - 1);
     if (alpha >= beta)
       return alpha;
   }
@@ -717,7 +719,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
   // recursion escape condition
   if (depth <= 0) {
     // run quiescence search
-    return quiescence(pos, thread, ss, alpha, beta, pv_node);
+    return quiescence(thread, ss, alpha, beta, pv_node);
   }
 
   tt_entry_t *tt_entry = read_hash_entry(pos, &tt_hit);
@@ -741,7 +743,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       int16_t bonus =
           MIN(QUIET_HISTORY_MAX_TT,
               (QUIET_HISTORY_TT_FACTOR * depth - QUIET_HISTORY_TT_BASE));
-      update_quiet_history(thread, pos, ss, tt_move, bonus);
+      update_quiet_history(thread, ss, tt_move, bonus);
     }
     return tt_score;
   }
@@ -756,9 +758,8 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     raw_static_eval =
         tt_static_eval != NO_SCORE
             ? tt_static_eval
-            : evaluate(thread, pos, &thread->accumulator[pos->ply]);
-    ss->eval = ss->static_eval =
-        adjust_static_eval(thread, pos, raw_static_eval);
+            : evaluate(thread, pos, &thread->accumulator[ply]);
+    ss->eval = ss->static_eval = adjust_static_eval(thread, raw_static_eval);
 
     if (tt_score != NO_SCORE &&
         ((tt_flag == HASH_FLAG_UPPER_BOUND && tt_score < ss->eval) ||
@@ -767,15 +768,14 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       ss->eval = tt_score;
     }
   } else {
-    raw_static_eval = evaluate(thread, pos, &thread->accumulator[pos->ply]);
-    ss->eval = ss->static_eval =
-        adjust_static_eval(thread, pos, raw_static_eval);
+    raw_static_eval = evaluate(thread, pos, &thread->accumulator[ply]);
+    ss->eval = ss->static_eval = adjust_static_eval(thread, raw_static_eval);
 
     write_hash_entry(tt_entry, pos, NO_SCORE, raw_static_eval, 0, 0,
                      HASH_FLAG_NONE, ss->tt_pv);
   }
 
-  int16_t correction = correction_value(thread, pos);
+  int16_t correction = correction_value(thread);
   (void)correction;
 
   uint8_t initial_depth = depth;
@@ -816,7 +816,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
   if (!pv_node && !in_check && !ss->excluded_move && depth <= RAZOR_DEPTH &&
       ss->static_eval + RAZOR_MARGIN * depth < alpha) {
     const int16_t razor_score =
-        quiescence(pos, thread, ss, alpha, beta, NON_PV);
+        quiescence(thread, ss, alpha, beta, NON_PV);
     if (razor_score <= alpha) {
       return razor_score;
     }
@@ -834,65 +834,62 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
   // Null Move Pruning
   if (cutnode && !in_check && !ss->excluded_move && !ss->null_move &&
-      pos->ply > thread->nmp_min_ply && ss->eval >= beta &&
+      ply > thread->nmp_min_ply && ss->eval >= beta &&
       ss->static_eval >= beta - NMP_MULTIPLIER * depth + NMP_BASE_ADD &&
       ss->eval >= ss->static_eval && !only_pawns(pos)) {
     int R = depth / NMP_DIVISER + NMP_BASE_REDUCTION;
     R = MIN(R, depth);
-    // preserve board state
-    position_t pos_copy = *pos;
 
-    null_move_copy_accumulator(thread, pos_copy.ply, pos_copy.ply + 1);
-
-    // increment ply
-    pos_copy.ply++;
+    // Copy current position to the next ply slot and advance.
+    null_move_copy_accumulator(thread, ply, ply + 1);
+    thread->positions[++thread->ply] = *pos;
+    position_t *null_pos = &thread->positions[thread->ply];
+    null_pos->ply = thread->ply;
 
     // increment repetition index & store hash key
     thread->repetition_index++;
     thread->repetition_table[thread->repetition_index] =
-        pos_copy.hash_keys.hash_key;
+        null_pos->hash_keys.hash_key;
 
     // hash enpassant if available
-    if (pos_copy.enpassant != no_sq)
-      pos_copy.hash_keys.hash_key ^= keys.enpassant_keys[pos_copy.enpassant];
+    if (null_pos->enpassant != no_sq)
+      null_pos->hash_keys.hash_key ^=
+          keys.enpassant_keys[null_pos->enpassant];
 
     // reset enpassant capture square
-    pos_copy.enpassant = no_sq;
+    null_pos->enpassant = no_sq;
 
+    // update pins on the pre-null-move position (same pieces, just need pin
+    // info for the null move evaluation)
     update_slider_pins(pos, white);
     update_slider_pins(pos, black);
 
     // switch the side, literally giving opponent an extra move to make
-    pos_copy.side ^= 1;
+    null_pos->side ^= 1;
 
     // hash the side
-    pos_copy.hash_keys.hash_key ^= keys.side_key;
+    null_pos->hash_keys.hash_key ^= keys.side_key;
 
-    prefetch_hash_entry(pos_copy.hash_keys.hash_key);
+    prefetch_hash_entry(null_pos->hash_keys.hash_key);
 
     ss->move = 0;
     ss->piece = NO_PIECE;
-    pos_copy.checkers = 0;
-    pos_copy.checker_count = 0;
+    null_pos->checkers = 0;
+    null_pos->checker_count = 0;
     (ss + 1)->null_move = 1;
 
-    calculate_threats(&pos_copy, ss + 1);
+    calculate_threats(null_pos, ss + 1);
 
     /* search moves with reduced depth to find beta cutoffs
        depth - 1 - R where R is a reduction limit */
-    current_score = -negamax(&pos_copy, thread, ss + 1, -beta, -beta + 1,
+    current_score = -negamax(thread, ss + 1, -beta, -beta + 1,
                              depth - R, !cutnode, NON_PV);
 
     (ss + 1)->null_move = 0;
 
-    // decrement ply
-    pos_copy.ply--;
-
-    // decrement repetition index
+    // restore ply (original position at thread->ply is unchanged)
+    thread->ply--;
     thread->repetition_index--;
-
-    // restore board state
-    //*pos = pos_copy;
 
     // return 0 if time is up
     if (thread->stopped == 1) {
@@ -904,10 +901,10 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       if (thread->nmp_min_ply != 0 || depth <= 14) {
         return current_score >= MATE_SCORE ? beta : current_score;
       }
-      thread->nmp_min_ply = pos->ply + 3 * (depth - R) / 4;
+      thread->nmp_min_ply = ply + 3 * (depth - R) / 4;
 
       const int16_t verification_score =
-          negamax(pos, thread, ss, beta - 1, beta, depth - R, 0, 0);
+          negamax(thread, ss, beta - 1, beta, depth - R, 0, 0);
 
       thread->nmp_min_ply = 0;
 
@@ -928,7 +925,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
     // Generate captures and good promotions for ProbCut
     picker_t probcut_picker;
-    init_picker(&probcut_picker, pos, thread, ss, 0, 0);
+    init_picker(&probcut_picker, thread, ss, 0, 0);
 
     // Try moves that look promising
     uint16_t move;
@@ -943,45 +940,43 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
         continue;
       }
 
-      // Preserve board state
-      position_t pos_copy = *pos;
+      // Copy current position to the next ply slot and advance.
+      thread->positions[++thread->ply] = *pos;
+      position_t *next_pos = &thread->positions[thread->ply];
+      next_pos->ply = thread->ply;
 
-      // Increment ply
-      pos->ply++;
-
-      // Increment repetition index & store hash key
+      // increment repetition index & store hash key
       thread->repetition_index++;
       thread->repetition_table[thread->repetition_index] =
-          pos->hash_keys.hash_key;
+          next_pos->hash_keys.hash_key;
 
-      // Make sure to make only legal moves
-      make_move(pos, move);
+      // make move on the new ply's position
+      make_move(next_pos, move);
 
-      calculate_threats(pos, ss + 1);
-      update_nnue(pos, thread, pos_copy.mailbox, move);
+      calculate_threats(next_pos, ss + 1);
+      update_nnue(next_pos, thread, pos->mailbox, move);
 
       ss->move = move;
-      ss->piece = pos_copy.mailbox[get_move_source(move)];
+      ss->piece = pos->mailbox[get_move_source(move)];
 
       thread->nodes++;
 
-      prefetch_hash_entry(pos->hash_keys.hash_key);
+      prefetch_hash_entry(next_pos->hash_keys.hash_key);
 
       // Shallow search with raised beta
-      int16_t probcut_score = -quiescence(pos, thread, ss + 1, -probcut_beta,
+      int16_t probcut_score = -quiescence(thread, ss + 1, -probcut_beta,
                                           -probcut_beta + 1, NON_PV);
 
       // If qsearch doesn't fail high, try a deeper search
       if (probcut_score >= probcut_beta) {
         probcut_score =
-            -negamax(pos, thread, ss + 1, -probcut_beta, -probcut_beta + 1,
+            -negamax(thread, ss + 1, -probcut_beta, -probcut_beta + 1,
                      probcut_depth, !cutnode, NON_PV);
       }
 
-      // Restore position
-      pos->ply--;
+      // Restore ply (original position at thread->ply is unchanged)
+      thread->ply--;
       thread->repetition_index--;
-      *pos = pos_copy;
 
       // Check if we need to stop
       if (thread->stopped == 1) {
@@ -1007,7 +1002,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
   }
 
   picker_t picker;
-  init_picker(&picker, pos, thread, ss, tt_move, 1);
+  init_picker(&picker, thread, ss, tt_move, 1);
 
   moves quiet_list[1];
   moves capture_list[1];
@@ -1043,9 +1038,9 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
                                    [is_square_threatened(
                                        ss, get_move_target(move))] *
                       SEARCH_QUIET_HIST_MULT +
-                  get_conthist_score(thread, pos, ss, move, 1) *
+                  get_conthist_score(thread, ss, move, 1) *
                       SEARCH_CONT1_HIST_MULT +
-                  get_conthist_score(thread, pos, ss, move, 2) *
+                  get_conthist_score(thread, ss, move, 2) *
                       SEARCH_CONT2_HIST_MULT
             : thread->capture_history
                           [pos->mailbox[get_move_source(move)]]
@@ -1096,7 +1091,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     // A rather simple idea that if our TT move is accurate we run a reduced
     // search to see if we can beat this score. If not we extend the TT move
     // search
-    if (pos->ply < thread->depth * 2 && !root_node && depth >= SE_DEPTH &&
+    if (ply < thread->depth * 2 && !root_node && depth >= SE_DEPTH &&
         move == tt_move && !ss->excluded_move &&
         tt_depth >= depth - SE_DEPTH_REDUCTION &&
         tt_flag != HASH_FLAG_UPPER_BOUND && abs(tt_score) < MATE_SCORE) {
@@ -1105,7 +1100,8 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
       ss->excluded_move = move;
 
-      const int16_t s_score = negamax(pos, thread, ss, s_beta - 1, s_beta,
+      // Singular search at the same ply (thread->ply is unchanged)
+      const int16_t s_score = negamax(thread, ss, s_beta - 1, s_beta,
                                       s_depth, cutnode, NON_PV);
 
       ss->excluded_move = 0;
@@ -1139,26 +1135,25 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       }
     }
 
-    // preserve board state
-    position_t pos_copy = *pos;
-
-    // increment ply
-    pos->ply++;
+    // Copy current position to the next ply slot and advance.
+    thread->positions[++thread->ply] = *pos;
+    position_t *next_pos = &thread->positions[thread->ply];
+    next_pos->ply = thread->ply;
 
     // increment repetition index & store hash key
     thread->repetition_index++;
     thread->repetition_table[thread->repetition_index] =
-        pos->hash_keys.hash_key;
+        next_pos->hash_keys.hash_key;
 
-    // make sure to make only legal moves
-    make_move(pos, move);
+    // make move on the new ply's position
+    make_move(next_pos, move);
 
-    calculate_threats(pos, ss + 1);
+    calculate_threats(next_pos, ss + 1);
 
-    update_nnue(pos, thread, pos_copy.mailbox, move);
+    update_nnue(next_pos, thread, pos->mailbox, move);
 
     ss->move = move;
-    ss->piece = pos_copy.mailbox[get_move_source(move)];
+    ss->piece = pos->mailbox[get_move_source(move)];
 
     // increment nodes count
     thread->nodes++;
@@ -1166,12 +1161,11 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
 
     if (quiet) {
       add_move(quiet_list, move);
-
     } else {
       add_move(capture_list, move);
     }
 
-    prefetch_hash_entry(pos->hash_keys.hash_key);
+    prefetch_hash_entry(next_pos->hash_keys.hash_key);
 
     uint64_t nodes_before_search = thread->nodes;
 
@@ -1190,7 +1184,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       R -= ss->tt_pv * LMR_TT_PV;
       R += (ss->tt_pv && tt_hit && tt_score <= alpha) * LMR_TT_SCORE;
       R -= (ss->tt_pv && cutnode) * LMR_TT_PV_CUTNODE;
-      R -= stm_in_check(pos) * LMR_IN_CHECK;
+      R -= stm_in_check(next_pos) * LMR_IN_CHECK;  // check on the new position
       R += (ss->cutoff_cnt > 3) * LMR_CUTOFF_CNT;
       R -= improving * LMR_IMPROVING;
 
@@ -1200,7 +1194,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
       int reduced_depth =
           MAX(1, MIN(new_depth - R, new_depth + cutnode)) + pv_node;
 
-      current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
+      current_score = -negamax(thread, ss + 1, -alpha - 1, -alpha,
                                reduced_depth, 1, NON_PV);
       ss->reduction = 0;
 
@@ -1210,37 +1204,31 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
         new_depth -= (current_score < best_score + LMR_SHALLOWER_MARGIN);
 
         if (new_depth > reduced_depth) {
-          current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
+          current_score = -negamax(thread, ss + 1, -alpha - 1, -alpha,
                                    new_depth, !cutnode, NON_PV);
         }
       }
       // Full Depth Search
     } else if (!pv_node || moves_seen > 1) {
-      current_score = -negamax(pos, thread, ss + 1, -alpha - 1, -alpha,
+      current_score = -negamax(thread, ss + 1, -alpha - 1, -alpha,
                                new_depth, !cutnode, NON_PV);
     }
 
     // Principal Variation Search
     if (pv_node && (moves_seen == 1 || current_score > alpha)) {
       current_score =
-          -negamax(pos, thread, ss + 1, -beta, -alpha, new_depth, 0, PV_NODE);
+          -negamax(thread, ss + 1, -beta, -alpha, new_depth, 0, PV_NODE);
     }
 
-    // decrement ply
-    pos->ply--;
-
-    // decrement repetition index
+    // restore ply (original position at thread->ply is unchanged)
+    thread->ply--;
     thread->repetition_index--;
-
-    // take move back
-    *pos = pos_copy;
 
     if (thread->index == 0 && root_node) {
       nodes_spent_table[move >> 4] += thread->nodes - nodes_before_search;
     }
 
-    // return INF so we can deal with timeout in case we are doing
-    // re-search
+    // return 0 if time is up
     if (thread->stopped == 1) {
       return 0;
     }
@@ -1255,27 +1243,26 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
         alpha = current_score;
 
         // write PV move
-        thread->pv.pv_table[pos->ply][pos->ply] = move;
+        thread->pv.pv_table[ply][ply] = move;
 
         // loop over the next ply
-        for (int next_ply = pos->ply + 1;
-             next_ply < thread->pv.pv_length[pos->ply + 1]; next_ply++)
+        for (int next_ply = ply + 1;
+             next_ply < thread->pv.pv_length[ply + 1]; next_ply++)
           // copy move from deeper ply into a current ply's line
-          thread->pv.pv_table[pos->ply][next_ply] =
-              thread->pv.pv_table[pos->ply + 1][next_ply];
+          thread->pv.pv_table[ply][next_ply] =
+              thread->pv.pv_table[ply + 1][next_ply];
 
         // adjust PV length
-        thread->pv.pv_length[pos->ply] = thread->pv.pv_length[pos->ply + 1];
+        thread->pv.pv_length[ply] = thread->pv.pv_length[ply + 1];
 
         // fail-hard beta cutoff
         if (alpha >= beta) {
           // on quiet moves
           if (quiet) {
-            update_quiet_histories(thread, pos, ss, quiet_list, best_move,
-                                   depth);
+            update_quiet_histories(thread, ss, quiet_list, best_move, depth);
           }
 
-          update_capture_history_moves(thread, pos, ss, capture_list, best_move,
+          update_capture_history_moves(thread, ss, capture_list, best_move,
                                        depth);
           ss->cutoff_cnt++;
           break;
@@ -1289,7 +1276,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
     // king is in check
     if (in_check)
       // return mating score (assuming closest distance to mating position)
-      return -MATE_VALUE + pos->ply;
+      return -MATE_VALUE + ply;
 
     // king is not in check
     else
@@ -1317,7 +1304,7 @@ static inline int16_t negamax(position_t *pos, thread_t *thread,
         !(get_move_capture(best_move) || is_move_promotion(best_move)) &&
         (hash_flag != HASH_FLAG_LOWER_BOUND || best_score > raw_static_eval) &&
         (hash_flag != HASH_FLAG_UPPER_BOUND || best_score <= raw_static_eval)) {
-      update_corrhist(thread, pos, raw_static_eval, best_score, depth);
+      update_corrhist(thread, raw_static_eval, best_score, depth);
     }
   }
 
@@ -1362,9 +1349,8 @@ static void print_thinking(thread_t *thread, int16_t score,
   printf("\n");
 }
 
-static inline uint8_t aspiration_windows(thread_t *thread, position_t *pos,
-                                         searchstack_t *ss, int16_t alpha,
-                                         int16_t beta) {
+static inline uint8_t aspiration_windows(thread_t *thread, searchstack_t *ss,
+                                         int16_t alpha, int16_t beta) {
   uint16_t window = ASP_WINDOW;
 
   uint8_t fail_high_count = 0;
@@ -1388,10 +1374,11 @@ static inline uint8_t aspiration_windows(thread_t *thread, position_t *pos,
     }
 
     // find best move within a given position
-    thread->score = negamax(pos, thread, ss + 7, alpha, beta,
+    // negamax reads root position from thread->positions[0] via thread->ply==0
+    thread->score = negamax(thread, ss + 7, alpha, beta,
                             thread->depth - fail_high_count, 0, PV_NODE);
 
-    // We hit an apspiration window cut-off before time ran out and we jumped
+    // We hit an aspiration window cut-off before time ran out and we jumped
     // to another depth with wider search which we didnt finish
     if (thread->stopped) {
       return 1;
@@ -1421,7 +1408,7 @@ static inline uint8_t aspiration_windows(thread_t *thread, position_t *pos,
 
 void *iterative_deepening(void *thread_void) {
   thread_t *thread = (thread_t *)thread_void;
-  position_t *pos = &thread->pos;
+  position_t *pos = &thread->positions[0];
 
   uint16_t prev_best_move = 0;
   int16_t average_score = NO_SCORE;
@@ -1458,7 +1445,7 @@ void *iterative_deepening(void *thread_void) {
 
     thread->seldepth = 0;
 
-    if (aspiration_windows(thread, pos, ss, alpha, beta)) {
+    if (aspiration_windows(thread, ss, alpha, beta)) {
       return NULL;
     }
 
@@ -1509,12 +1496,15 @@ void *iterative_deepening(void *thread_void) {
 }
 
 // search position for the best move
+//TODO: Pass in const ply so we can always restore it to
+//original without search changing it
 void search_position(position_t *pos, thread_t *threads) {
   pthread_t pthreads[thread_count];
   for (int i = 0; i < thread_count; ++i) {
     threads[i].nodes = 0;
     threads[i].stopped = 0;
-    threads[i].pos = *pos;
+    threads[i].positions[threads[0].ply] = *pos;
+    threads[i].ply = threads[0].ply;
     threads[i].score = -INF;
     threads[i].quit = 0;
     threads[i].nmp_min_ply = 0;

--- a/Source/search.c
+++ b/Source/search.c
@@ -488,7 +488,7 @@ static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
   if (tt_hit) {
     tt_move = tt_entry->move;
     tt_was_pv |= tt_entry->tt_pv;
-    tt_score = score_from_tt(pos, tt_entry->score);
+    tt_score = score_from_tt(ply, tt_entry->score);
     tt_static_eval = tt_entry->static_eval;
     tt_flag = tt_entry->flag;
   }
@@ -526,7 +526,7 @@ static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
     // fail-hard beta cutoff
     if (best_score >= beta) {
       if (!tt_hit) {
-        write_hash_entry(tt_entry, pos, NO_SCORE, raw_static_eval, 0, 0,
+        write_hash_entry(tt_entry, pos, ply, NO_SCORE, raw_static_eval, 0, 0,
                          HASH_FLAG_NONE, tt_was_pv);
       }
       if (abs(best_score) < MATE_SCORE && abs(beta) < MATE_SCORE) {
@@ -585,7 +585,6 @@ static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
     // Copy current ply's position to the next ply slot and advance.
     thread->positions[++thread->ply] = *pos;
     position_t *next_pos = &thread->positions[thread->ply];
-    next_pos->ply = thread->ply;
 
     // increment repetition index & store hash key
     thread->repetition_index++;
@@ -652,7 +651,7 @@ static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
     hash_flag = HASH_FLAG_UPPER_BOUND;
   }
 
-  write_hash_entry(tt_entry, pos, best_score, raw_static_eval, 0, best_move,
+  write_hash_entry(tt_entry, pos, ply, best_score, raw_static_eval, 0, best_move,
                    hash_flag, tt_was_pv);
 
   return best_score;
@@ -726,7 +725,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
   if (tt_hit) {
     ss->tt_pv |= tt_entry->tt_pv;
-    tt_score = score_from_tt(pos, tt_entry->score);
+    tt_score = score_from_tt(ply, tt_entry->score);
     tt_static_eval = tt_entry->static_eval;
     tt_depth = tt_entry->depth;
     tt_flag = tt_entry->flag;
@@ -771,7 +770,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     raw_static_eval = evaluate(thread, pos, &thread->accumulator[ply]);
     ss->eval = ss->static_eval = adjust_static_eval(thread, raw_static_eval);
 
-    write_hash_entry(tt_entry, pos, NO_SCORE, raw_static_eval, 0, 0,
+    write_hash_entry(tt_entry, pos, ply, NO_SCORE, raw_static_eval, 0, 0,
                      HASH_FLAG_NONE, ss->tt_pv);
   }
 
@@ -844,7 +843,6 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     null_move_copy_accumulator(thread, ply, ply + 1);
     thread->positions[++thread->ply] = *pos;
     position_t *null_pos = &thread->positions[thread->ply];
-    null_pos->ply = thread->ply;
 
     // increment repetition index & store hash key
     thread->repetition_index++;
@@ -943,7 +941,6 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       // Copy current position to the next ply slot and advance.
       thread->positions[++thread->ply] = *pos;
       position_t *next_pos = &thread->positions[thread->ply];
-      next_pos->ply = thread->ply;
 
       // increment repetition index & store hash key
       thread->repetition_index++;
@@ -986,7 +983,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       // If shallow search failed high, we can prune
       if (probcut_score >= probcut_beta) {
         // Store in transposition table
-        write_hash_entry(tt_entry, pos, probcut_score, raw_static_eval,
+        write_hash_entry(tt_entry, pos, ply, probcut_score, raw_static_eval,
                          probcut_depth + 1, move, HASH_FLAG_LOWER_BOUND,
                          ss->tt_pv);
         return probcut_score;
@@ -1138,7 +1135,6 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     // Copy current position to the next ply slot and advance.
     thread->positions[++thread->ply] = *pos;
     position_t *next_pos = &thread->positions[thread->ply];
-    next_pos->ply = thread->ply;
 
     // increment repetition index & store hash key
     thread->repetition_index++;
@@ -1297,7 +1293,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       hash_flag = HASH_FLAG_UPPER_BOUND;
     }
     // store hash entry with the score equal to alpha
-    write_hash_entry(tt_entry, pos, best_score, raw_static_eval, depth,
+    write_hash_entry(tt_entry, pos, ply, best_score, raw_static_eval, depth,
                      best_move, hash_flag, ss->tt_pv);
 
     if (!in_check &&

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -102,7 +102,6 @@ typedef struct position {
   uint64_t checkers;
   uint16_t fullmove;
   uint8_t checker_count;
-  uint8_t ply;
   uint8_t fifty;
   uint8_t mailbox[64];
   uint8_t side;
@@ -122,7 +121,7 @@ typedef struct searchinfo {
   uint64_t nodes;
   uint64_t starttime;
   position_t positions[MAX_PLY + 10];
-  uint8_t    ply;
+  uint8_t ply;
   uint64_t repetition_table[2000];
   uint32_t repetition_index;
   uint32_t nmp_min_ply;

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -121,7 +121,8 @@ typedef struct searchinfo {
   accumulator_t accumulator[MAX_PLY + 10];
   uint64_t nodes;
   uint64_t starttime;
-  position_t pos;
+  position_t positions[MAX_PLY + 10];
+  uint8_t    ply;
   uint64_t repetition_table[2000];
   uint32_t repetition_index;
   uint32_t nmp_min_ply;

--- a/Source/transposition.c
+++ b/Source/transposition.c
@@ -161,12 +161,12 @@ uint8_t can_use_score(int alpha, int beta, int tt_score, uint8_t flag) {
   return 0;
 }
 
-int16_t score_from_tt(position_t *pos, int16_t score) {
+int16_t score_from_tt(const uint8_t ply, int16_t score) {
 
   if (score < -MATE_SCORE)
-    score += pos->ply;
+    score += ply;
   if (score > MATE_SCORE)
-    score -= pos->ply;
+    score -= ply;
   return score;
 }
 
@@ -195,7 +195,7 @@ tt_entry_t *read_hash_entry(position_t *pos, uint8_t *tt_hit) {
 }
 
 // write hash entry data
-void write_hash_entry(tt_entry_t *tt_entry, position_t *pos, int16_t score,
+void write_hash_entry(tt_entry_t *tt_entry, position_t *pos, const uint8_t ply, int16_t score,
                       int16_t static_eval, uint8_t depth, uint16_t move,
                       uint8_t hash_flag, uint8_t tt_pv) {
   uint8_t replace =
@@ -212,9 +212,9 @@ void write_hash_entry(tt_entry_t *tt_entry, position_t *pos, int16_t score,
   // store score independent from the actual path
   // from root node (position) to current node (position)
   if (score < -MATE_SCORE)
-    score -= pos->ply;
+    score -= ply;
   if (score > MATE_SCORE)
-    score += pos->ply;
+    score += ply;
 
   // write hash entry data
   tt_entry->hash_key = get_hash_low_bits(pos->hash_keys.hash_key);

--- a/Source/transposition.h
+++ b/Source/transposition.h
@@ -20,11 +20,11 @@ extern tt_t tt;
 void clear_hash_table(void);
 void prefetch_hash_entry(uint64_t hash_key);
 uint8_t can_use_score(int alpha, int beta, int tt_score, uint8_t flag);
-int16_t score_from_tt(position_t *pos, int16_t score);
+int16_t score_from_tt(const uint8_t ply, int16_t score);
 tt_entry_t* read_hash_entry(position_t *pos, uint8_t *tt_hit);
-void write_hash_entry(tt_entry_t *tt_entry, position_t *pos, int16_t score, int16_t static_eval,
-                      uint8_t depth, uint16_t move, uint8_t hash_flag,
-                      uint8_t tt_pv);
+void write_hash_entry(tt_entry_t *tt_entry, position_t *pos, const uint8_t ply, int16_t score,
+                      int16_t static_eval, uint8_t depth, uint16_t move,
+                      uint8_t hash_flag, uint8_t tt_pv);
 void init_hash_table(uint64_t mb);
 uint64_t generate_hash_key(position_t *pos);
 int hash_full(void);

--- a/Source/uci.c
+++ b/Source/uci.c
@@ -421,7 +421,7 @@ static void handle_isready(uci_ctx_t *ctx, char *args) {
 static void handle_position(uci_ctx_t *ctx, char *args) {
   (void)args;
   parse_position(ctx->pos, *ctx->threads, ctx->input);
-  init_accumulator(ctx->pos, &(*ctx->threads)->accumulator[ctx->pos->ply]);
+  init_accumulator(ctx->pos, &(*ctx->threads)->accumulator[ctx->threads[0]->ply]);
   init_finny_tables(*ctx->threads, ctx->pos);
 }
 
@@ -621,7 +621,7 @@ void uci_loop(position_t *pos, int argc, char *argv[]) {
   printf("Quanticade %s by DarkNeutrino\n", version);
 
   parse_position(pos, threads, "position startpos");
-  init_accumulator(pos, &threads->accumulator[pos->ply]);
+  init_accumulator(pos, &threads->accumulator[threads[0].ply]);
   init_finny_tables(threads, pos);
 
   uci_ctx_t ctx = {
@@ -647,7 +647,7 @@ void uci_loop(position_t *pos, int argc, char *argv[]) {
         memset(threads, 0, sizeof(thread_t));
         printf("\nPosition %d/%d (%s)\n", i, 49, bench_positions[i]);
         parse_position(pos, threads, input);
-        init_accumulator(pos, &threads->accumulator[pos->ply]);
+        init_accumulator(pos, &threads->accumulator[threads[0].ply]);
         init_finny_tables(threads, pos);
         time_control(pos, threads, "go depth 13");
         search_position(pos, threads);


### PR DESCRIPTION
Switches the desynchronized position_t in thread with a position_t stack dependent on ply that has been moved to thread from pos.

Should solve several issues with corrhist and probably other things.

Fails STC nonreg. Seems neutralish at LTC tho the test was taking ages. AKA we let tune solve this. Its a bug that should not be there either way.