### PR TITLE
search.c: Do LMR later if its a root node

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1169,7 +1169,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     int new_depth = depth + extensions - 1;
 
     // LMR
-    if (depth >= 2 && moves_seen > 1) {
+    if (depth >= 2 && moves_seen > 1 + root_node) {
       int R = lmr[quiet][depth][MIN(255, moves_seen)] * 1024;
       R += !pv_node * LMR_PV_NODE;
       R -= ss->history_score * (quiet ? LMR_HISTORY_QUIET : LMR_HISTORY_NOISY) /


### PR DESCRIPTION
Elo   | 0.94 +- 1.33 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 0.58 (-2.25, 2.89) [0.00, 3.00]
Games | N: 68820 W: 16106 L: 15919 D: 36795
Penta | [245, 8010, 17708, 8207, 240]
https://furybench.com/test/5923/

Takes too long and seems to be good.