### PR TITLE
search.c: Low Depth Search Extensions

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1130,6 +1130,13 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       else if (cutnode) {
         extensions -= 2;
       }
+    } 
+    // Low Depth Singular Extensions (LDSE)
+    else if (depth <= 7
+                && !in_check
+                && ss->static_eval <= alpha - 25
+                && tt_flag == HASH_FLAG_LOWER_BOUND) {
+                extensions = 1;
     }
 
     // Copy current position to the next ply slot and advance.


### PR DESCRIPTION
Elo   | 1.88 +- 1.91 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 1.76 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29364 W: 6672 L: 6513 D: 16179
Penta | [15, 3265, 7960, 3430, 12]
https://furybench.com/test/5975/

Taking too long. The margin tuning will make it be good either way