### PR TITLE
search.c: Increment moves_seen before pre-move loop pruning

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1015,6 +1015,8 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       continue;
     }
 
+    moves_seen++;
+
     ss->history_score =
         quiet
             ? thread->quiet_history[pos->side][get_move_source(move)]
@@ -1053,11 +1055,11 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
       // Late Move Pruning
       if (!pv_node && quiet &&
-          moves_seen >= lmp_treshold && !only_pawns(pos)) {
+          moves_seen - 1 >= lmp_treshold && !only_pawns(pos)) {
         picker.skip_quiets = 1;
       }
 
-      int r = lmr[quiet][MIN(63, depth)][MIN(63, moves_seen)];
+      int r = lmr[quiet][MIN(63, depth)][MIN(63, moves_seen - 1)];
       r += !pv_node;
       int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
       // Futility Pruning
@@ -1164,7 +1166,6 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
     // increment nodes count
     thread->nodes++;
-    moves_seen++;
 
     if (quiet) {
       add_move(quiet_list, move);


### PR DESCRIPTION
Elo   | 1.25 +- 2.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 30356 W: 7121 L: 7012 D: 16223
Penta | [101, 3566, 7742, 3661, 108]
https://furybench.com/test/6067/