### PR TITLE
search.c: Remove the margin from moves_seen

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1055,11 +1055,11 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
       // Late Move Pruning
       if (!pv_node && quiet &&
-          moves_seen - 1 >= lmp_treshold && !only_pawns(pos)) {
+          moves_seen >= lmp_treshold && !only_pawns(pos)) {
         picker.skip_quiets = 1;
       }
 
-      int r = lmr[quiet][MIN(63, depth)][MIN(63, moves_seen - 1)];
+      int r = lmr[quiet][MIN(63, depth)][MIN(63, moves_seen)];
       r += !pv_node;
       int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
       // Futility Pruning


### PR DESCRIPTION
Elo   | -0.17 +- 1.09 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 102424 W: 23937 L: 23988 D: 54499
Penta | [352, 12157, 26243, 12110, 350]
https://furybench.com/test/6068/