### PR TITLE
search.c: Remove the broken FP mate guard

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1063,7 +1063,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       r += !pv_node;
       int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
       // Futility Pruning
-      if (current_score > -MATE_SCORE && lmr_depth <= FP_DEPTH && !in_check &&
+      if (lmr_depth <= FP_DEPTH && !in_check &&
           quiet &&
           ss->static_eval + lmr_depth * FP_MULTIPLIER + FP_ADDITION +
                   ss->history_score / FP_HISTORY_DIVISOR <=


### PR DESCRIPTION
Elo   | 2.50 +- 2.45 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-2.75, 0.25]
Games | N: 19334 W: 4617 L: 4478 D: 10239
Penta | [51, 2144, 5149, 2261, 62]
https://furybench.com/test/6071/