### PR TITLE
search.c: Simply depth margin for do deeper

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -8,6 +8,7 @@
 #include "movegen.h"
 #include "nnue.h"
 #include "pyrrhic/tbprobe.h"
+#include "stats.h"
 #include "see.h"
 #include "structs.h"
 #include "syzygy.h"
@@ -86,7 +87,7 @@ int LMR_TT_PV_CUTNODE = 887;
 int LMR_TT_SCORE = 868;
 int LMR_CUTOFF_CNT = 809;
 int LMR_IMPROVING = 988;
-int LMR_DEEPER_MARGIN = 30;
+int LMR_DEEPER_MARGIN = 35;
 int LMR_SHALLOWER_MARGIN = 6;
 int LMP_BETA_MARGIN = 15;
 int ASP_WINDOW = 13;
@@ -1216,8 +1217,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       ss->reduction = 0;
 
       if (current_score > alpha && R != 0) {
-        new_depth += (current_score > best_score + LMR_DEEPER_MARGIN +
-                                          round(LMR_DEEPER_MULT * new_depth));
+        new_depth += (current_score > best_score + LMR_DEEPER_MARGIN);
         new_depth -= (current_score < best_score + LMR_SHALLOWER_MARGIN);
 
         if (new_depth > reduced_depth) {

--- a/Source/uci.c
+++ b/Source/uci.c
@@ -11,6 +11,7 @@
 #include "pyrrhic/tbprobe.h"
 #include "search.h"
 #include "spsa.h"
+#include "stats.h"
 #include "structs.h"
 #include "threads.h"
 #include "transposition.h"


### PR DESCRIPTION
Elo   | -0.27 +- 0.86 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-2.75, 0.25]
Games | N: 163698 W: 38207 L: 38334 D: 87157
Penta | [511, 19558, 41868, 19371, 541]
https://furybench.com/test/6076/