### PR TITLE
see.c: Correct the square at which we remove the captured pawn

### DIFF
--- a/Source/see.c
+++ b/Source/see.c
@@ -90,8 +90,10 @@ int SEE(position_t *pos, int move, int threshold) {
   // Let occupied suppose that the move was actually made
   occupied = pos->occupancies[both];
   occupied = (occupied ^ (1ull << from)) | (1ull << to);
-  if (enpassant)
-    occupied ^= (1ull << pos->enpassant);
+  if (enpassant) {
+    int ep_sq = pos->side == white ? to + 8 : to - 8;
+    occupied ^= (1ull << ep_sq);
+  }
 
   // Get all pieces which attack the target square. And with occupied
   // so that we do not let the same piece attack twice


### PR DESCRIPTION
Elo   | 0.17 +- 1.24 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [-2.75, 0.25]
Games | N: 75468 W: 17278 L: 17240 D: 40950
Penta | [231, 8434, 20381, 8442, 246]
https://furybench.com/test/6109/