### PR TITLE
search.c: Introduce assymetric aspiration window increase

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1430,10 +1430,13 @@ void *iterative_deepening(void *thread_void) {
 
         alpha = MAX(-INF, alpha - window);
         fail_high_count = 0;
+        window += 28 * window / 128;
       }
 
       else if (thread->score >= beta) {
         beta = MIN(INF, beta + window);
+
+        window += 62 * window / 128;
 
         if (alpha < 2000) {
           ++fail_high_count;
@@ -1444,8 +1447,6 @@ void *iterative_deepening(void *thread_void) {
                             : (average_score + thread->score) / 2;
         break;
       }
-
-      window += ASP_WINDOW_MULTIPLIER * window / 1024;
     }
 
     if (thread->index == 0) {


### PR DESCRIPTION
Elo   | 0.54 +- 1.21 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 5.29 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 83766 W: 19157 L: 19028 D: 45581
Penta | [292, 9805, 21529, 9996, 261]
https://furybench.com/test/6113/

Struggles to pass 0 3 bounds so lets merge it nonreg and tune it later