### PR TITLE
Add missing Makefile dependency for pgo target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ $(TMPDIR):
 
 
 # Usual disservin yoink for makefile related stuff
-pgo:
+pgo: $(EVALFILE)
 	$(CC) $(CFLAGS) $(PGO_GEN) $(NATIVE) $(INSTRUCTIONS) -MMD -MP -o $(EXE) $(SOURCES) -lm $(LDFLAGS)
 	./$(EXE) bench
 	$(PGO_MERGE)


### PR DESCRIPTION
Add a missing pgo target dependency to $(EVALFILE). This fixes the build on a fresh checkout.

Fixes #356

bench: 3098520