### PR TITLE
search.c: Make SEE probcut threshold based on eval

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -930,7 +930,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     while ((move = select_next(&probcut_picker)) != 0) {
 
       // Skip moves that don't pass SEE threshold
-      if (!SEE(pos, move, probcut_beta - ss->eval)) {
+      if (!SEE(pos, move, probcut_beta - ss->static_eval)) {
         continue;
       }
 

--- a/Source/search.c
+++ b/Source/search.c
@@ -930,7 +930,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     while ((move = select_next(&probcut_picker)) != 0) {
 
       // Skip moves that don't pass SEE threshold
-      if (!SEE(pos, move, PROBCUT_SEE_THRESHOLD)) {
+      if (!SEE(pos, move, probcut_beta - ss->eval)) {
         continue;
       }
 


### PR DESCRIPTION
Elo   | 3.79 +- 2.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19442 W: 4541 L: 4329 D: 10572
Penta | [44, 2183, 5070, 2365, 59]
https://furybench.com/test/6170/