### PR TITLE
search.c: Dont trigger qsearch LMP if its direct check

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -592,7 +592,7 @@ static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
         continue;
 
       if (get_move_target(move) != previous_square) {
-        if (moves_seen >= 3) {
+        if (moves_seen >= 3 && !is_direct_check(pos, move)) {
           continue;
         }
       }


### PR DESCRIPTION
Elo   | 0.62 +- 1.31 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | -0.52 (-2.25, 2.89) [0.00, 3.00]
Games | N: 71392 W: 16608 L: 16481 D: 38303
Penta | [242, 8366, 18321, 8557, 210]
https://furybench.com/test/6180/