### PR TITLE
search.c: History Pruning

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1178,6 +1178,11 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
         continue;
       }
 
+      if (quiet && depth <= 4 && ss->history_score < -2300 * depth * depth) {
+        picker.skip_quiets = 1;
+        continue;
+      }
+
       int see_treshold;
       if (!get_move_capture(move)) {
         see_treshold = -SEE_QUIET * depth;


### PR DESCRIPTION
Elo   | 1.83 +- 1.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 59116 W: 13964 L: 13652 D: 31500
Penta | [262, 6958, 14823, 7236, 279]
https://furybench.com/test/6184/