### PR TITLE
search.c: Introduce Bad Noisy Futility Pruning

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1183,6 +1183,11 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
         continue;
       }
 
+      int noisy_futility_margin = ss->static_eval + 150 * depth;
+      if (!in_check && depth < 10 && picker.stage == STAGE_BAD_NOISY && noisy_futility_margin <= alpha && !is_direct_check(pos, move)) {
+        break;
+      }
+
       int see_treshold;
       if (!get_move_capture(move)) {
         see_treshold = -SEE_QUIET * depth;


### PR DESCRIPTION
Elo   | 2.69 +- 1.98 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 31410 W: 7419 L: 7176 D: 16815
Penta | [96, 3631, 8037, 3816, 125]
https://furybench.com/test/6185/