### PR TITLE
search.c: Reduce more if bound is exact in LMR

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1244,6 +1244,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       R -= stm_in_check(next_pos) * LMR_IN_CHECK; // check on the new position
       R += (ss->cutoff_cnt > 3) * LMR_CUTOFF_CNT;
       R -= improving * LMR_IMPROVING;
+      R += (bound == HASH_FLAG_EXACT) * 1024;;
 
       ss->reduction = R;
 


### PR DESCRIPTION
Elo   | 1.66 +- 1.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 68270 W: 16147 L: 15820 D: 36303
Penta | [244, 8040, 17257, 8333, 261]
https://furybench.com/test/6183/