### PR TITLE
search.c: Update corrhist in excluded move

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1397,13 +1397,13 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     // store hash entry with the score equal to alpha
     write_hash_entry(tt_entry, pos, ply, best_score, raw_static_eval, depth,
                      best_move, bound, ss->tt_pv);
+  }
 
-    if (!in_check &&
+  if (!in_check &&
         !(get_move_capture(best_move) || is_move_promotion(best_move)) &&
         (bound != HASH_FLAG_LOWER_BOUND || best_score > raw_static_eval) &&
         (bound != HASH_FLAG_UPPER_BOUND || best_score <= raw_static_eval)) {
-      update_corrhist(thread, raw_static_eval, best_score, depth);
-    }
+    update_corrhist(thread, raw_static_eval, best_score, depth);
   }
 
   // node (position) fails low


### PR DESCRIPTION
Elo   | 2.50 +- 2.49 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-2.75, 0.25]
Games | N: 19296 W: 4447 L: 4308 D: 10541
Penta | [44, 2233, 4973, 2336, 62]
https://furybench.com/test/6226/