### PR TITLE
search.c: Use correction value in LMR

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1255,6 +1255,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       R += (ss->cutoff_cnt > 3) * LMR_CUTOFF_CNT;
       R -= improving * LMR_IMPROVING;
       R += (bound == HASH_FLAG_EXACT) * 1024;;
+      R -= 2048 * abs(correction) / 1024;
 
       ss->reduction = R;
 


### PR DESCRIPTION
Elo   | 2.43 +- 2.02 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.31 (-2.25, 2.89) [0.00, 3.00]
Games | N: 26194 W: 6107 L: 5924 D: 14163
Penta | [15, 2880, 7124, 3063, 15]
https://furybench.com/test/6221/