### PR TITLE
Source: Fix fifty move rule scaling

### DIFF
--- a/Source/arch.h
+++ b/Source/arch.h
@@ -7,7 +7,6 @@
 #define L3_SIZE 32
 #define OUTPUT_BUCKETS 8
 #define KING_BUCKETS 16
-#define SCALE 400
 #define INPUT_QUANT 255
 #define L1_QUANT 128
 #define INPUT_SHIFT 9

--- a/Source/history.c
+++ b/Source/history.c
@@ -13,7 +13,7 @@ int CORR_HISTORY_MINMAX = 351;
 int PAWN_CORR_HISTORY_MULTIPLIER = 2523;
 int NON_PAWN_CORR_HISTORY_MULTIPLIER = 1559;
 
-int FIFTY_MOVE_SCALING = 180;
+int FIFTY_MOVE_SCALING = 200;
 int CORR_HISTORY_BONUS_SCALER = 130;
 
 int HISTORY_MAX = 8192;
@@ -141,7 +141,7 @@ uint8_t static_eval_within_bounds(int16_t static_eval, int16_t score,
 int16_t adjust_static_eval(thread_t *thread, int16_t static_eval) {
   position_t *pos = &thread->positions[thread->ply];
   const float fifty_move_scaler =
-      (float)((FIFTY_MOVE_SCALING - (float)pos->fifty) / 200);
+      (float)((FIFTY_MOVE_SCALING - (float)pos->fifty) / FIFTY_MOVE_SCALING);
   static_eval = static_eval * fifty_move_scaler;
   const int pawn_correction =
       thread->correction_history[pos->side][pos->hash_keys.pawn_key & 16383] *

--- a/Source/nnue.c
+++ b/Source/nnue.c
@@ -14,6 +14,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+int EVAL_SCALE = 360;
+
 nnue_t nnue;
 
 struct raw_net {
@@ -488,7 +490,7 @@ int nnue_eval_pos(position_t *pos, accumulator_t *accumulator) {
   }
   // TODO reduce add
 
-  return (int16_t)(result * SCALE);
+  return (int16_t)(result * EVAL_SCALE);
 }
 
 int nnue_evaluate(thread_t *thread, position_t *pos,
@@ -772,7 +774,7 @@ int nnue_evaluate(thread_t *thread, position_t *pos,
   }
 
 #endif
-  return (int16_t)(result * SCALE);
+  return (int16_t)(result * EVAL_SCALE);
 }
 
 static inline void

--- a/Source/spsa.c
+++ b/Source/spsa.c
@@ -148,6 +148,8 @@ extern int FIFTY_MOVE_SCALING;
 extern int CORR_HISTORY_BONUS_SCALER;
 extern int HISTORY_MAX;
 
+extern int EVAL_SCALE;
+
 // TM
 extern double DEF_TIME_MULTIPLIER;
 extern double DEF_INC_MULTIPLIER;
@@ -336,6 +338,7 @@ void init_spsa_table(void) {
   SPSA_INT(FIFTY_MOVE_SCALING, 1);
   SPSA_INT(CORR_HISTORY_BONUS_SCALER, 1);
   SPSA_INT(HISTORY_MAX, 0);
+  SPSA_INT(EVAL_SCALE, 1);
   SPSA_INT_NAME("SEE_PAWN", SEEPieceValues[PAWN], 1);
   SPSA_INT_NAME("SEE_KNIGHT", SEEPieceValues[KNIGHT], 1);
   SPSA_INT_NAME("SEE_BISHOP", SEEPieceValues[BISHOP], 1);


### PR DESCRIPTION
Elo   | 4.09 +- 3.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.03 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 12996 W: 3223 L: 3070 D: 6703
Penta | [42, 1494, 3284, 1625, 53]
https://furybench.com/test/6310/