### PR TITLE
search.c: Simplify PV in LMR depth

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1171,7 +1171,6 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       }
 
       int r = lmr[quiet][MIN(63, depth)][MIN(63, moves_seen)];
-      r += !pv_node;
       int lmr_depth = MAX(1, depth - 1 - MAX(r, 1));
       // Futility Pruning
       if (lmr_depth <= FP_DEPTH && !in_check && quiet &&


### PR DESCRIPTION
Elo   | 0.98 +- 1.85 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 35100 W: 8317 L: 8218 D: 18565
Penta | [93, 4109, 9059, 4184, 105]
https://furybench.com/test/6336/