### PR TITLE
Source: Simplify the source square in capture history

### DIFF
--- a/Source/history.c
+++ b/Source/history.c
@@ -235,11 +235,11 @@ void update_capture_history(thread_t *thread, searchstack_t *ss, int move,
                           : pos->side ? pos->mailbox[get_move_target(move) - 8]
                                       : pos->mailbox[get_move_target(move) + 8];
 
-  thread->capture_history[pos->mailbox[from]][prev_target_piece][from][target]
+  thread->capture_history[pos->mailbox[from]][prev_target_piece][target]
                          [is_square_threatened(ss, from)]
                          [is_square_threatened(ss, target)] +=
       bonus -
-      thread->capture_history[pos->mailbox[from]][prev_target_piece][from]
+      thread->capture_history[pos->mailbox[from]][prev_target_piece]
                              [target][is_square_threatened(ss, from)]
                              [is_square_threatened(ss, target)] *
           abs(bonus) / HISTORY_MAX;

--- a/Source/search.c
+++ b/Source/search.c
@@ -316,7 +316,7 @@ static inline void score_noisy(thread_t *thread, searchstack_t *ss,
 
     entry.score = mvv[target_piece % 6] * MO_MVV_MULT;
     entry.score +=
-        thread->capture_history[pos->mailbox[source]][target_piece][source]
+        thread->capture_history[pos->mailbox[source]][target_piece]
                                [target][source_threatened][target_threatened] *
         MO_CAPT_HIST_MULT;
     entry.score /= 1024;
@@ -1144,7 +1144,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
             : thread->capture_history
                           [pos->mailbox[get_move_source(move)]]
                           [pos->mailbox[get_move_target(move)]]
-                          [get_move_source(move)][get_move_target(move)]
+                          [get_move_target(move)]
                           [is_square_threatened(ss, get_move_source(move))]
                           [is_square_threatened(ss, get_move_target(move))] *
                       SEARCH_CAPT_HIST_MULT +

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -134,7 +134,7 @@ typedef struct searchinfo {
   int16_t w_non_pawn_correction_history[2][16384];
   int16_t quiet_history[2][64][64][2][2];
   int16_t continuation_history[13][64][12][64];
-  int16_t capture_history[12][13][64][64][2][2];
+  int16_t capture_history[12][13][64][2][2];
   int16_t pawn_history[2048][12][64];
   lazy_acc_state_t lazy[MAX_PLY + 10];
   uint8_t depth;


### PR DESCRIPTION
Elo   | 1.25 +- 2.00 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 29970 W: 7091 L: 6983 D: 15896
Penta | [85, 3501, 7702, 3615, 82]
https://furybench.com/test/6337/