### PR TITLE
Fix mate score calculations in UCI outputting

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1434,9 +1434,9 @@ static void print_thinking(thread_t *thread, int16_t score,
   printf("info depth %d seldepth %d score ", current_depth, thread->seldepth);
 
   if (score > -MATE_VALUE && score < -MATE_SCORE) {
-    printf("mate %d ", -(score + MATE_VALUE) / 2 - 1);
+    printf("mate %d ", -(MATE_VALUE - abs(score) + 1) / 2);
   } else if (score > MATE_SCORE && score < MATE_VALUE) {
-    printf("mate %d ", (MATE_VALUE - score) / 2 + 1);
+    printf("mate %d ", (MATE_VALUE - abs(score) + 1) / 2);
   } else {
     if (disable_norm) {
       printf("cp %d ", score);


### PR DESCRIPTION
position fen k7/8/1K6/5R2/8/8/8/8 b - - 0 1
position fen 1k6/8/1K6/5R2/8/8/8/8 w - - 0 1
position fen k7/8/1K6/1R6/8/8/8/8 w - - 0 1
position fen Qk6/8/1K6/1R6/8/8/8/8 b - - 0 1

Four positions. Before this patch, Quanticade says:
mate -2, mate 1, mate 2, mate -3

After the patch, and matching Stockfish:
mate -1, mate 1, mate 2, mate -2