### PR TITLE
search.c: Adjust LMP treshold with history score

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1172,7 +1172,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       }
 
       // Late Move Pruning
-      if (!pv_node && quiet && moves_seen >= lmp_treshold && !only_pawns(pos)) {
+      if (!pv_node && quiet && moves_seen >= lmp_treshold + ss->history_score / 8192 && !only_pawns(pos)) {
         picker.skip_quiets = 1;
       }
 


### PR DESCRIPTION
Elo   | 1.19 +- 1.16 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 1.88 (-2.25, 2.89) [0.00, 3.00]
Games | N: 89880 W: 21266 L: 20957 D: 47657
Penta | [253, 10497, 23141, 10786, 263]
https://furybench.com/test/6347/

Tune will get it LOL