### PR TITLE
search.c: Movepicker bonus to moves that give direct check & pass SEE

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -360,6 +360,8 @@ static inline void score_quiet(thread_t *thread, searchstack_t *ss,
                             [pos->mailbox[source]][target] *
             MO_PAWN_HIST_MULT;
     entry->score /= 1024;
+
+    entry->score += 8192 * (is_direct_check(pos, move) && SEE(pos, move, -100));
   }
 }
 


### PR DESCRIPTION
Elo   | 1.74 +- 1.40 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 62340 W: 15074 L: 14762 D: 32504
Penta | [162, 7329, 15909, 7575, 195]
https://furybench.com/test/6348/