### PR TITLE
movegen.c: Use already precomputed checkers

### DIFF
--- a/Source/movegen.c
+++ b/Source/movegen.c
@@ -222,14 +222,10 @@ uint8_t is_legal(position_t *pos, uint16_t move) {
   uint8_t  stm       = pos->side;
   uint8_t  king      = get_lsb(pos->bitboards[KING + 6 * stm]);
 
-  uint64_t checkers      = attackers_to(pos, king, pos->occupancies[both]) &
-                           pos->occupancies[stm ^ 1];
-  uint8_t  checker_count = popcount(checkers);
-
-  if (checkers && source != king) {
-    if (checker_count > 1)
+  if (pos->checkers && source != king) {
+    if (pos->checker_count > 1)
       return 0;
-    uint8_t attacker   = get_lsb(checkers);
+    uint8_t attacker   = get_lsb(pos->checkers);
     uint8_t mod_target = get_move_enpassant(move) ? target - (stm ? 8 : -8) : target;
     if (between[king][attacker] & BB(target) || mod_target == attacker)
       goto pinners;


### PR DESCRIPTION
Elo   | 5.05 +- 3.11 (95%)
SPRT  | 2.0+0.02s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 16570 W: 4512 L: 4271 D: 7787
Penta | [198, 1874, 3971, 1973, 269]
https://furybench.com/test/6369/