### PR TITLE
search.c: Dont stop extending

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1059,7 +1059,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
   // A rather simple idea that if our TT move is accurate we run a reduced
   // search to see if we can beat this score. If not we extend the TT move
   // search
-  if (ply < thread->depth * 2 && !root_node && !ss->excluded_move &&
+  if (!root_node && !ss->excluded_move &&
       potential_singularity) {
     const int s_beta = tt_score - (SE_BETA_BASE + SE_BETA_MULTIPLIER *
                                                       (ss->tt_pv && !pv_node)) *


### PR DESCRIPTION

Elo   | -0.00 +- 1.14 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 79040 W: 17903 L: 17903 D: 43234
Penta | [34, 8666, 22111, 8684, 25]
https://furybench.com/test/6394/