### PR TITLE
Use ss->eval in NMP

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -635,7 +635,8 @@ static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
 
     ss->move = move;
     ss->piece = pos->mailbox[get_move_source(move)];
-    ss->continuation_history = thread->continuation_history[ss->piece][get_history_target(move)];
+    ss->continuation_history =
+        thread->continuation_history[ss->piece][get_history_target(move)];
 
     thread->nodes++;
 
@@ -890,9 +891,9 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
   // Null Move Pruning
   if (cutnode && !in_check && !ss->excluded_move && !ss->null_move &&
-      ply > thread->nmp_min_ply && ss->eval >= beta &&
+      ply > thread->nmp_min_ply &&
       ss->eval >= beta - NMP_MULTIPLIER * depth + NMP_BASE_ADD &&
-      !is_loss(beta) && !only_pawns(pos)) {
+      !is_loss(beta) && !is_win(ss->eval) && !only_pawns(pos)) {
     int R = (depth * NMP_DIVISER + NMP_BASE_REDUCTION) / 256;
     R = MIN(R, depth);
 
@@ -1013,7 +1014,8 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
       ss->move = move;
       ss->piece = pos->mailbox[get_move_source(move)];
-      ss->continuation_history = thread->continuation_history[ss->piece][get_history_target(move)];
+      ss->continuation_history =
+          thread->continuation_history[ss->piece][get_history_target(move)];
 
       thread->nodes++;
 
@@ -1243,7 +1245,8 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
     ss->move = move;
     ss->piece = pos->mailbox[get_move_source(move)];
-    ss->continuation_history = thread->continuation_history[ss->piece][get_history_target(move)];
+    ss->continuation_history =
+        thread->continuation_history[ss->piece][get_history_target(move)];
 
     // increment nodes count
     thread->nodes++;

--- a/Source/search.c
+++ b/Source/search.c
@@ -891,8 +891,8 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
   // Null Move Pruning
   if (cutnode && !in_check && !ss->excluded_move && !ss->null_move &&
       ply > thread->nmp_min_ply && ss->eval >= beta &&
-      ss->static_eval >= beta - NMP_MULTIPLIER * depth + NMP_BASE_ADD &&
-      ss->eval >= ss->static_eval && !is_loss(beta) && !only_pawns(pos)) {
+      ss->eval >= beta - NMP_MULTIPLIER * depth + NMP_BASE_ADD &&
+      !is_loss(beta) && !only_pawns(pos)) {
     int R = (depth * NMP_DIVISER + NMP_BASE_REDUCTION) / 256;
     R = MIN(R, depth);
 


### PR DESCRIPTION
Elo   | -0.03 +- 1.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.75 (-2.25, 2.89) [-4.00, 0.00]
Games | N: 58354 W: 13674 L: 13679 D: 31001
Penta | [135, 6909, 15091, 6910, 132]
https://furybench.com/test/6398/