### PR TITLE
net52

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NETWORK_NAME = net48.nnue
+NETWORK_NAME = net52.nnue
 _THIS       := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 _ROOT       := $(_THIS)
 EVALFILE    ?= $(NETWORK_NAME)


### PR DESCRIPTION
Elo   | 6.43 +- 3.44 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10974 W: 2802 L: 2599 D: 5573
Penta | [55, 1215, 2746, 1414, 57]
https://furybench.com/test/6487/

Elo   | 7.79 +- 3.71 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8122 W: 2001 L: 1819 D: 4302
Penta | [5, 869, 2133, 1047, 7]
https://furybench.com/test/6488/

DFRC:
Elo   | 59.08 +- 12.51 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 1508 W: 568 L: 314 D: 626
Penta | [23, 117, 283, 245, 86]
https://furybench.com/test/6489/

Additional 2B data of which 1B is adversarial 5K node. 0.5B of normal 25K node data and 0.5B of adversarial DFRC 5K node data.