### PR TITLE
net53

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NETWORK_NAME = net52.nnue
+NETWORK_NAME = net53.nnue
 _THIS       := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 _ROOT       := $(_THIS)
 EVALFILE    ?= $(NETWORK_NAME)


### PR DESCRIPTION
Elo   | 6.89 +- 3.56 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10040 W: 2602 L: 2403 D: 5035
Penta | [45, 1105, 2518, 1310, 42]
https://furybench.com/test/6497/

Elo   | 8.29 +- 3.82 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7542 W: 1855 L: 1675 D: 4012
Penta | [5, 790, 2000, 972, 4]
https://furybench.com/test/6498/

piece count filtering