### PR TITLE
search.c: Do not enter SE if tt_score is invalid

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -839,7 +839,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
   const uint8_t potential_singularity =
       depth >= SE_DEPTH && tt_depth >= depth - SE_DEPTH_REDUCTION &&
-      tt_flag != HASH_FLAG_UPPER_BOUND && abs(tt_score) < MATE_SCORE;
+      tt_flag != HASH_FLAG_UPPER_BOUND && tt_score != NO_SCORE && !is_loss(tt_score);
 
   if ((ss - 2)->static_eval != NO_SCORE && !in_check) {
     improvement = ss->static_eval - (ss - 2)->static_eval;


### PR DESCRIPTION
Elo   | 0.18 +- 1.37 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 64322 W: 15318 L: 15285 D: 33719
Penta | [184, 7624, 16521, 7639, 193]
https://furybench.com/test/6606/