### PR TITLE
search.c: Add history to bnfp margin

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1206,7 +1206,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
         continue;
       }
 
-      int noisy_futility_margin = ss->static_eval + BNFP_MARGIN * depth;
+      int noisy_futility_margin = ss->static_eval + BNFP_MARGIN * depth + ss->history_score / 29;
       if (!in_check && depth < 10 && picker.stage == STAGE_BAD_NOISY &&
           noisy_futility_margin <= alpha && !is_direct_check(pos, &check_info, move)) {
         break;


### PR DESCRIPTION
Elo   | 1.56 +- 1.27 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 70930 W: 16860 L: 16541 D: 37529
Penta | [105, 8150, 18664, 8413, 133]
https://furybench.com/test/6868/