### PR TITLE
search.c: Do NOT have depth 0 at root

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1539,7 +1539,7 @@ void *iterative_deepening(void *thread_void) {
       // negamax reads root position from thread->positions[0] via
       // thread->ply==0
       thread->score = negamax(thread, ss + 7, alpha, beta,
-                              thread->depth - fail_high_count, 0, PV_NODE);
+                              MAX(thread->depth - fail_high_count, 1), 0, PV_NODE);
 
       // We hit an aspiration window cut-off before time ran out and we jumped
       // to another depth with wider search which we didnt finish


### PR DESCRIPTION
Elo   | 0.28 +- 1.34 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 57020 W: 13486 L: 13440 D: 30094
Penta | [77, 5969, 16384, 5991, 89]
https://furybench.com/test/6888/