### PR TITLE
search.c: Disable qsearch pruning in check

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -605,7 +605,7 @@ static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
 
     moves_seen++;
 
-    if (!is_loss(best_score)) {
+    if (!in_check && !is_loss(best_score)) {
       if (!SEE(pos, move, -QS_SEE_THRESHOLD))
         continue;
 


### PR DESCRIPTION
Elo   | 0.18 +- 1.36 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 64486 W: 15422 L: 15389 D: 33675
Penta | [163, 7582, 16703, 7649, 146]
https://furybench.com/test/6966/