### PR TITLE
search.c: LMR check

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1280,6 +1280,10 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
         R -= 512 + 440 * (beta - alpha) / thread->root_delta;
       }
 
+      if (!!next_pos->checkers) {
+        R -= 1024;
+      }
+
       ss->reduction = R;
 
       R = R / 1024;


### PR DESCRIPTION
Elo   | 5.08 +- 2.93 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.25, 2.89) [0.00, 3.00]
Games | N: 13966 W: 3426 L: 3222 D: 7318
Penta | [34, 1561, 3602, 1739, 47]
https://furybench.com/test/7013/