### PR TITLE
net56

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-NETWORK_NAME = net55.nnue
+NETWORK_NAME = net56.nnue
 PROCESSED_NET = processed.bin
 _THIS       := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 _ROOT       := $(_THIS)


### PR DESCRIPTION
Elo   | 20.40 +- 6.24 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.02 (-2.25, 2.89) [0.00, 3.00]
Games | N: 3274 W: 903 L: 711 D: 1660
Penta | [10, 307, 824, 473, 23]
https://furybench.com/test/7032/

Elo   | 19.93 +- 16.81 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 0.38 (-2.25, 2.89) [0.00, 3.00]
Games | N: 384 W: 104 L: 82 D: 198
Penta | [0, 34, 102, 56, 0]
https://furybench.com/test/7033/

12B more positions from net55