### PR TITLE
search.c: Combine neg ext and cutnode to -3

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1103,12 +1103,8 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     }
 
     // Negative Extensions
-    else if (tt_score >= beta) {
-      extensions -= 2 + !pv_node;
-    }
-
-    else if (cutnode) {
-      extensions -= 2;
+    else if (tt_score >= beta || cutnode) {
+      extensions -= 3;
     }
   }
   // Low Depth Singular Extensions (LDSE)


### PR DESCRIPTION
Elo   | 1.42 +- 2.06 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 27344 W: 6556 L: 6444 D: 14344
Penta | [44, 3185, 7115, 3271, 57]
https://furybench.com/test/7049/