### PR TITLE
search.c: Reduce more given tt score below alpha and tt depth below depth

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1266,6 +1266,9 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       int R = reduction;
       (void)correction;
 
+      R += 464 * (tt_score != NO_SCORE && tt_score <= alpha);
+      R += 326 * (tt_score != NO_SCORE && tt_depth < depth);
+
       if (quiet) {
         R -= 198 * ss->history_score / 1024;
       } else {


### PR DESCRIPTION
Elo   | 1.73 +- 1.39 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 60410 W: 14365 L: 14065 D: 31980
Penta | [122, 6950, 15770, 7232, 131]
https://furybench.com/test/7068/