### PR TITLE
search.c: ttpv in LMR

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1282,7 +1282,9 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       if (!!next_pos->checkers) {
         R -= 1024;
       }
-
+      if (ss->tt_pv) {
+        R -= 768;
+      }
       if (cutnode) {
         R += 1536;
         R += (tt_move == 0) * 2048;


### PR DESCRIPTION
Elo   | 5.24 +- 3.01 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 13196 W: 3255 L: 3056 D: 6885
Penta | [22, 1491, 3398, 1640, 47]
https://furybench.com/test/7094/