### PR TITLE
search.c: Reduce less if score is above alpha in ttpv

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1284,6 +1284,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       }
       if (ss->tt_pv) {
         R -= 768;
+        R -= 512 * (tt_score != NO_SCORE && tt_score > alpha);
       }
       if (cutnode) {
         R += 1536;


### PR DESCRIPTION
Elo   | 2.33 +- 1.78 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 37730 W: 9022 L: 8769 D: 19939
Penta | [72, 4407, 9675, 4618, 93]
https://furybench.com/test/7098/