### PR TITLE
search.c: Remove was in check lmr

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1267,7 +1267,6 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
       R += !pv_node * LMR_PV_NODE;
       R -= ss->history_score * (quiet ? LMR_HISTORY_QUIET : LMR_HISTORY_NOISY) /
            (quiet ? LMR_QUIET_HIST_DIV : LMR_CAPT_HIST_DIV);
-      R -= in_check * LMR_WAS_IN_CHECK;
       R += cutnode * LMR_CUTNODE;
       R -= (tt_depth >= depth) * LMR_TT_DEPTH;
       R -= ss->tt_pv * LMR_TT_PV;


### PR DESCRIPTION
Elo   | 2.94 +- 3.00 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 12986 W: 3128 L: 3018 D: 6840
Penta | [20, 1487, 3378, 1579, 29]
https://furybench.com/test/7131/