### PR TITLE
Prefetch better

### DIFF
--- a/Source/movegen.c
+++ b/Source/movegen.c
@@ -243,6 +243,8 @@ pinners:;
   return !pinned || (line[source][target] & BB(king));
 }
 
+extern void prefetch_hash_entry(uint64_t);
+
 void make_move(position_t *pos, uint16_t move) {
   // parse move
   uint8_t capture        = get_move_capture(move);
@@ -254,6 +256,13 @@ void make_move(position_t *pos, uint16_t move) {
   uint8_t enpass         = get_move_enpassant(move);
   uint8_t castling       = get_move_castling(move);
   uint8_t stm            = pos->side;
+  uint8_t bb_piece = pos->mailbox[target_square];
+
+  uint64_t approximate_key = pos->hash_keys.hash_key;
+  approximate_key ^= keys.piece_keys[bb_piece][target_square];
+  approximate_key ^= keys.piece_keys[piece][source_square] ^ keys.piece_keys[piece][target_square];
+
+  prefetch_hash_entry(approximate_key);
 
   // increment fifty move rule counter
   pos->fifty++;
@@ -264,7 +273,6 @@ void make_move(position_t *pos, uint16_t move) {
   // handling capture moves
   if (capture && !enpass) {
     pos->fifty = 0;
-    uint8_t bb_piece = pos->mailbox[target_square];
     if (bb_piece != NO_PIECE && get_bit(pos->bitboards[bb_piece], target_square)) {
       pop_bit(pos->bitboards[bb_piece], target_square);
       pos->hash_keys.hash_key ^= keys.piece_keys[bb_piece][target_square];

--- a/Source/movegen.c
+++ b/Source/movegen.c
@@ -261,6 +261,7 @@ void make_move(position_t *pos, uint16_t move) {
   uint64_t approximate_key = pos->hash_keys.hash_key;
   approximate_key ^= keys.piece_keys[bb_piece][target_square];
   approximate_key ^= keys.piece_keys[piece][source_square] ^ keys.piece_keys[piece][target_square];
+  approximate_key ^= keys.side_key;
 
   prefetch_hash_entry(approximate_key);
 

--- a/Source/search.c
+++ b/Source/search.c
@@ -648,8 +648,6 @@ static inline int16_t quiescence(thread_t *thread, searchstack_t *ss,
       add_move(capture_list, move);
     }
 
-    prefetch_hash_entry(next_pos->hash_keys.hash_key);
-
     // score current move
     score = -quiescence(thread, ss + 1, -beta, -alpha, pv_node);
 
@@ -1022,8 +1020,6 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
       thread->nodes++;
 
-      prefetch_hash_entry(next_pos->hash_keys.hash_key);
-
       // Shallow search with raised beta
       int16_t probcut_score =
           -quiescence(thread, ss + 1, -probcut_beta, -probcut_beta + 1, NON_PV);
@@ -1241,8 +1237,6 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
     } else {
       add_move(capture_list, move);
     }
-
-    prefetch_hash_entry(next_pos->hash_keys.hash_key);
 
     const uint64_t nodes_before_search = thread->nodes;
 

--- a/Source/structs.h
+++ b/Source/structs.h
@@ -53,7 +53,7 @@ typedef struct moves {
 } moves;
 
 typedef struct keys {
-  uint64_t piece_keys[12][64];
+  uint64_t piece_keys[13][64];
   uint64_t enpassant_keys[64];
   uint64_t castle_keys[16];
   uint64_t side_key;


### PR DESCRIPTION
LLR    +2.91  (-2.25, +2.89) bounds  [0.00, 3.00] elo
ELO    +10.21 ± 4.43  (+5.79, +14.64) 95%
CONF   4.0+0.04s · 1 thread · 16 mb hash
GAMES  6,570  (26.5% 1,742W  49.9% 3,279D  23.6% 1,549L)
PENTA  [38⁻²  655⁻¹  1,717⁰  826⁺¹  49⁺²]
https://furybench.com/test/7295/