### PR TITLE
search.c: Simplify LMR extensions for cutnode

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1266,7 +1266,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
 
       R = R / 1024;
       int reduced_depth =
-          MAX(1, MIN(new_depth - R, new_depth + cutnode)) + pv_node;
+          MAX(1, MIN(new_depth - R, new_depth + 1)) + pv_node;
 
       score = -negamax(thread, ss + 1, -alpha - 1, -alpha, reduced_depth, 1,
                        NON_PV);


### PR DESCRIPTION
ELO    2.05 +- 2.58 (95%)
SPRT   10.0+0.10s Threads=1 Hash=16MB
LLR    2.94 (-2.94, 2.94) [-3.00, 1.00]
GAMES  N: 17444 W: 4162 L: 4059 D: 9223
PENTA  [30, 2007, 4557, 2086, 42]
https://furybench.com/test/7316/