### PR TITLE
search.c: Verify that TT move actually exists before going into SE

### DIFF
--- a/Source/search.c
+++ b/Source/search.c
@@ -1067,7 +1067,7 @@ static inline int16_t negamax(thread_t *thread, searchstack_t *ss,
   // A rather simple idea that if our TT move is accurate we run a reduced
   // search to see if we can beat this score. If not we extend the TT move
   // search
-  if (!root_node && !ss->excluded_move &&
+  if (!root_node && !ss->excluded_move && tt_move &&
       potential_singularity) {
     const int s_beta = tt_score - (SE_BETA_BASE + SE_BETA_MULTIPLIER *
                                                       (ss->tt_pv && !pv_node)) *


### PR DESCRIPTION
ELO    0.79 +- 1.77 (95%)
SPRT   10.0+0.10s Threads=1 Hash=16MB
LLR    3.00 (-2.94, 2.94) [-3.00, 1.00]
GAMES  N: 34242 W: 8166 L: 8088 D: 17988
PENTA  [59, 3700, 9510, 3808, 44]
https://furybench.com/test/7369/